### PR TITLE
Fix pulumi action env mismatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,11 +27,9 @@ jobs:
         env:
           JWT_SIGNING_KEY: ${{ secrets.JWT_SIGNING_KEY }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-      - uses: pulumi/actions@v3
-        with:
-          command: up
-          stack-name: dev
-          work-dir: infra
+      - name: Deploy stack
+        run: pulumi up --yes
+        working-directory: infra
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}


### PR DESCRIPTION
## Summary
- run `pulumi up` directly in workflow so installed Python packages are used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bd2f0c40c832e9262b0ac656f9a49