### PR TITLE
Add macOS laptop event tracker

### DIFF
--- a/eventgen/laptop/mac/README.md
+++ b/eventgen/laptop/mac/README.md
@@ -1,9 +1,19 @@
 # macOS
 
-Placeholders for utilities that collect system information on macOS machines. Example ideas:
+This folder contains utilities that emit laptop status information as `Event` objects.
 
-- Battery percentage via `pmset`.
-- Current Wi‑Fi network.
-- Disk usage and uptime.
+`tracker.py` gathers several metrics using built-in macOS tools and outputs each
+measurement as a JSON encoded event. It currently collects:
 
-The scripts should package these metrics into `Event` objects for the platform.
+- **laptop.in_use** – idle time in seconds and whether the machine is considered
+  active (idle less than five minutes).
+- **laptop.battery** – battery percentage and charging status from `pmset`.
+- **laptop.location** – latitude and longitude via `CoreLocationCLI` when
+  available.
+- **laptop.program** – name of the frontmost application using AppleScript.
+
+Run the script directly to print the events:
+
+```bash
+python tracker.py
+```

--- a/eventgen/laptop/mac/__init__.py
+++ b/eventgen/laptop/mac/__init__.py
@@ -1,0 +1,3 @@
+from .tracker import collect_events
+
+__all__ = ["collect_events"]

--- a/eventgen/laptop/mac/tracker.py
+++ b/eventgen/laptop/mac/tracker.py
@@ -1,0 +1,128 @@
+import json
+import subprocess
+import getpass
+from datetime import datetime
+from typing import List, Optional, Tuple
+
+from events import Event
+
+
+IDLE_THRESHOLD = 300  # seconds
+
+
+def _get_output(cmd: List[str]) -> str:
+    """Run command and return decoded stdout."""
+    try:
+        return subprocess.check_output(cmd, stderr=subprocess.DEVNULL).decode().strip()
+    except Exception:
+        return ""
+
+
+def get_idle_time() -> Optional[float]:
+    """Return idle time in seconds or None if unavailable."""
+    out = _get_output(["ioreg", "-n", "IOHIDSystem"])
+    for line in out.splitlines():
+        if "HIDIdleTime" in line:
+            try:
+                idle_ns = int(line.split("=")[-1].strip())
+                return idle_ns / 1e9
+            except Exception:
+                return None
+    return None
+
+
+def get_battery_status() -> Tuple[Optional[int], Optional[bool]]:
+    """Return (percentage, charging) if available."""
+    out = _get_output(["pmset", "-g", "batt"])
+    for line in out.splitlines():
+        if "%" in line:
+            try:
+                token = [t for t in line.split() if "%" in t][0]
+                percent = int(token.strip("%;"))
+                charging = "charging" in line.lower()
+                return percent, charging
+            except Exception:
+                return None, None
+    return None, None
+
+
+def get_location() -> Tuple[Optional[float], Optional[float]]:
+    """Return (lat, lon) via CoreLocationCLI if available."""
+    out = _get_output(["CoreLocationCLI", "-f", "json"])
+    if not out:
+        return None, None
+    try:
+        data = json.loads(out)
+        return float(data.get("latitude")), float(data.get("longitude"))
+    except Exception:
+        return None, None
+
+
+def get_active_program() -> Optional[str]:
+    """Return name of the frontmost application."""
+    out = _get_output([
+        "osascript",
+        "-e",
+        'tell application "System Events" to get name of first process whose frontmost is true',
+    ])
+    return out or None
+
+
+def collect_events(user_id: Optional[str] = None) -> List[Event]:
+    """Collect laptop events for the current macOS system."""
+    user_id = user_id or getpass.getuser()
+    events: List[Event] = []
+    idle = get_idle_time()
+    if idle is not None:
+        events.append(
+            Event(
+                timestamp=datetime.utcnow(),
+                source="mac.laptop",
+                type="laptop.in_use",
+                user_id=user_id,
+                metadata={"idle_seconds": idle, "in_use": idle < IDLE_THRESHOLD},
+            )
+        )
+
+    percent, charging = get_battery_status()
+    if percent is not None:
+        events.append(
+            Event(
+                timestamp=datetime.utcnow(),
+                source="mac.laptop",
+                type="laptop.battery",
+                user_id=user_id,
+                metadata={"percentage": percent, "charging": charging},
+            )
+        )
+
+    lat, lon = get_location()
+    if lat is not None and lon is not None:
+        events.append(
+            Event(
+                timestamp=datetime.utcnow(),
+                source="mac.laptop",
+                type="laptop.location",
+                user_id=user_id,
+                metadata={"latitude": lat, "longitude": lon},
+            )
+        )
+
+    program = get_active_program()
+    if program:
+        events.append(
+            Event(
+                timestamp=datetime.utcnow(),
+                source="mac.laptop",
+                type="laptop.program",
+                user_id=user_id,
+                metadata={"application": program},
+            )
+        )
+
+    return events
+
+
+if __name__ == "__main__":
+    for event in collect_events():
+        print(json.dumps(event.to_dict()))


### PR DESCRIPTION
## Summary
- implement `tracker.py` to generate macOS laptop events
- expose `collect_events` in package
- document the new mac event generator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bd8c9f040832eb3c8aa748af8117e