### PR TITLE
Add task execution support to worker agent

### DIFF
--- a/agents/openai_shell_agent.py
+++ b/agents/openai_shell_agent.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 import os
 import subprocess
 import json
@@ -12,7 +12,7 @@ class OpenAIShellAgent(Agent):
 
     name = "openai-shell"
 
-    def run(self, commands: List[str]) -> str:
+    def run(self, commands: Union[List[str], str]) -> str:
         try:
             import openai
         except ModuleNotFoundError as e:
@@ -37,8 +37,13 @@ class OpenAIShellAgent(Agent):
             },
         }
 
+        if isinstance(commands, str):
+            instructions = [commands]
+        else:
+            instructions = commands
+
         outputs = []
-        for instruction in commands:
+        for instruction in instructions:
             response = openai.ChatCompletion.create(
                 messages=[{"role": "user", "content": instruction}],
                 model=model,

--- a/events/__init__.py
+++ b/events/__init__.py
@@ -87,21 +87,26 @@ class WorkerTaskEvent(Event):
     """Event describing a task to run against a user's repository."""
 
     commands: List[str] = field(default_factory=list)
+    task: Optional[str] = None
     repo_url: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "WorkerTaskEvent":
         base = Event.from_dict(data)
-        cmds = base.metadata.get("commands")
-        if not cmds:
-            raise ValueError("metadata.commands required")
+        cmds = base.metadata.get("commands") or []
+        task = base.metadata.get("task")
+        if not cmds and not task:
+            raise ValueError("metadata.commands or metadata.task required")
         repo = base.metadata.get("repo_url")
-        return cls(**asdict(base), commands=cmds, repo_url=repo)
+        return cls(**asdict(base), commands=cmds, task=task, repo_url=repo)
 
     def to_dict(self) -> Dict[str, Any]:
         d = super().to_dict()
         meta = dict(d.get("metadata", {}))
-        meta["commands"] = self.commands
+        if self.commands:
+            meta["commands"] = self.commands
+        if self.task is not None:
+            meta["task"] = self.task
         if self.repo_url is not None:
             meta["repo_url"] = self.repo_url
         d["metadata"] = meta

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -46,7 +46,7 @@ def test_openai_shell_agent(monkeypatch):
     monkeypatch.setenv('OPENAI_API_KEY', 'sk')
     monkeypatch.setenv('OPENAI_MODEL', 'model-test')
 
-    result = agent.run(['say hello'])
+    result = agent.run('say hello')
     assert 'hello' in result
     assert captured['model'] == 'model-test'
     assert captured['tools'][0]['function']['name'] == 'bash'

--- a/tests/test_worker_main.py
+++ b/tests/test_worker_main.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import json
+import importlib
+from datetime import datetime
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from events import WorkerTaskEvent
+
+
+def test_worker_main_runs_agent(monkeypatch, capsys):
+    # create a dummy agent
+    from agents import AGENT_REGISTRY, Agent
+
+    class DummyAgent(Agent):
+        name = "openai-shell"
+        def run(self, commands):
+            assert commands == "do stuff"
+            return "ok"
+
+    AGENT_REGISTRY["openai-shell"] = DummyAgent()
+
+    event = WorkerTaskEvent(
+        timestamp=datetime.utcnow(),
+        source="t",
+        type="worker.task",
+        user_id="u1",
+        metadata={},
+        task="do stuff"
+    )
+    os.environ["WORKER_EVENT"] = json.dumps(event.to_dict())
+
+    module = importlib.import_module("worker")
+    exit_code = module.main()
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "ok" in captured.out
+

--- a/tests/test_worker_task_event.py
+++ b/tests/test_worker_task_event.py
@@ -34,3 +34,18 @@ def test_worker_task_round_trip():
     out = event.to_dict()
     assert out["metadata"]["commands"] == cmds
     assert out["metadata"]["repo_url"] == "https://example.com/repo.git"
+
+
+def test_worker_task_with_task():
+    now = datetime.now()
+    data = {
+        "timestamp": now.isoformat(),
+        "source": "s",
+        "type": "worker.task",
+        "userID": "u1",
+        "metadata": {"task": "run tests"},
+    }
+    event = WorkerTaskEvent.from_dict(data)
+    assert event.task == "run tests"
+    out = event.to_dict()
+    assert out["metadata"]["task"] == "run tests"

--- a/worker.py
+++ b/worker.py
@@ -1,0 +1,38 @@
+import json
+import os
+import sys
+
+from agents import AGENT_REGISTRY
+from events import WorkerTaskEvent
+
+
+def main() -> int:
+    event_json = os.environ.get("WORKER_EVENT")
+    if not event_json:
+        print("WORKER_EVENT not set", file=sys.stderr)
+        return 1
+    try:
+        data = json.loads(event_json)
+        event = WorkerTaskEvent.from_dict(data)
+    except Exception as e:
+        print(f"Invalid WORKER_EVENT: {e}", file=sys.stderr)
+        return 1
+
+    agent_name = event.metadata.get("agent", "openai-shell")
+    agent = AGENT_REGISTRY.get(agent_name)
+    if not agent:
+        print(f"Unknown agent: {agent_name}", file=sys.stderr)
+        return 1
+
+    if event.task:
+        result = agent.run(event.task)
+    else:
+        result = agent.run(event.commands)
+
+    if result:
+        print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- extend `WorkerTaskEvent` to carry a single task description
- update `OpenAIShellAgent` to accept a task string
- implement new container entrypoint `worker.py`
- test new functionality including worker main script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bd97fb0a0832eb83e3318e2b694ec