### PR TITLE
Track event history on new events

### DIFF
--- a/azure-function/ChatResponder/__init__.py
+++ b/azure-function/ChatResponder/__init__.py
@@ -54,6 +54,7 @@ def main(msg: func.ServiceBusMessage) -> None:
         type="llm.chat.response",
         user_id=event.user_id,
         metadata={"reply": reply},
+        history=event.history + [event.to_dict()],
     )
 
     message = ServiceBusMessage(json.dumps(out_event.to_dict()))

--- a/azure-function/WorkerTaskRunner/__init__.py
+++ b/azure-function/WorkerTaskRunner/__init__.py
@@ -100,6 +100,7 @@ def main(msg: func.ServiceBusMessage) -> None:
         type="worker.task.result",
         user_id=event.user_id,
         metadata={"result": result},
+        history=event.history + [event.to_dict()],
     )
 
     message = ServiceBusMessage(json.dumps(out_event.to_dict()))

--- a/events/__init__.py
+++ b/events/__init__.py
@@ -12,6 +12,7 @@ class Event:
     user_id: str
     metadata: Dict[str, Any] = field(default_factory=dict)
     id: Optional[str] = None
+    history: List[Dict[str, Any]] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Event":
@@ -35,6 +36,10 @@ class Event:
             timestamp = datetime.fromtimestamp(ts)
         else:
             raise ValueError("invalid timestamp")
+        history = data.get("history", [])
+        if not isinstance(history, list):
+            raise ValueError("history must be a list")
+
         return cls(
             timestamp=timestamp,
             source=data["source"],
@@ -42,6 +47,7 @@ class Event:
             user_id=data["userID"],
             metadata=data.get("metadata", {}),
             id=data.get("id") or uuid.uuid4().hex,
+            history=history,
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -52,6 +58,7 @@ class Event:
             "userID": self.user_id,
             "metadata": self.metadata,
             "id": self.id,
+            "history": self.history,
         }
 
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -28,8 +28,10 @@ def test_event_round_trip():
     }
     event = Event.from_dict(data)
     assert event.user_id == "u1"
+    assert event.history == []
     out = event.to_dict()
     assert out["userID"] == "u1"
+    assert out["history"] == []
 
 
 def test_event_auto_generates_id():
@@ -41,10 +43,12 @@ def test_event_auto_generates_id():
     }
     event = Event.from_dict(data)
     assert event.id is not None
+    assert event.history == []
     # id should be a 32 character hex string
     assert isinstance(event.id, str) and len(event.id) == 32
     out = event.to_dict()
     assert out["id"] == event.id
+    assert out["history"] == []
 
 
 def test_event_parses_z_timezone():
@@ -56,3 +60,4 @@ def test_event_parses_z_timezone():
     }
     event = Event.from_dict(data)
     assert event.timestamp.isoformat() == "2023-01-01T00:00:00+00:00"
+    assert event.history == []

--- a/tests/test_llm_chat_event.py
+++ b/tests/test_llm_chat_event.py
@@ -71,5 +71,7 @@ def test_llmchat_round_trip():
     }
     event = LLMChatEvent.from_dict(data)
     assert event.messages == msgs
+    assert event.history == []
     out = event.to_dict()
     assert out["metadata"]["messages"] == msgs
+    assert out["history"] == []

--- a/tests/test_worker_task_event.py
+++ b/tests/test_worker_task_event.py
@@ -31,6 +31,8 @@ def test_worker_task_round_trip():
     event = WorkerTaskEvent.from_dict(data)
     assert event.commands == cmds
     assert event.repo_url == "https://example.com/repo.git"
+    assert event.history == []
     out = event.to_dict()
     assert out["metadata"]["commands"] == cmds
     assert out["metadata"]["repo_url"] == "https://example.com/repo.git"
+    assert out["history"] == []


### PR DESCRIPTION
## Summary
- extend `Event` model with a `history` field
- include origin event when `ChatResponder` and `WorkerTaskRunner` emit new events
- update unit tests for new field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bd9f3c568832eb34738bdb0d976a4