### PR TITLE
Fix run-from-package config

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -197,7 +197,6 @@ func_app = web.WebApp(
             web.NameValuePairArgs(name="AzureWebJobsStorage", value=storage_connection_string),
             web.NameValuePairArgs(name="FUNCTIONS_EXTENSION_VERSION", value="~4"),
             web.NameValuePairArgs(name="FUNCTIONS_WORKER_RUNTIME", value="python"),
-            web.NameValuePairArgs(name="WEBSITE_RUN_FROM_PACKAGE", value="1"),  # Enable ZIP deployment
             web.NameValuePairArgs(name="COSMOS_CONNECTION", value=cosmos_connection_string),
             web.NameValuePairArgs(name="COSMOS_DATABASE", value="lightning"),
             web.NameValuePairArgs(name="SCHEDULE_CONTAINER", value="schedules"),


### PR DESCRIPTION
## Summary
- drop `WEBSITE_RUN_FROM_PACKAGE` from the initial `site_config`
- keep the setting in `WebAppApplicationSettings` so it contains the ZIP URL

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'Request' from 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_683c58c37230832ea47f1b188d963da7