### PR TITLE
Replace Output.concat with string default

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -21,7 +21,7 @@ location = config.get("location") or "centralindia"
 openai_api_key = config.require_secret("openaiApiKey")
 jwt_signing_key = config.require_secret("jwtSigningKey")
 # Worker image will be configured by GitHub Actions or default to ACR image
-worker_image = config.get("workerImage") or pulumi.Output.concat("lightningacr.azurecr.io/worker-task:latest")
+worker_image = config.get("workerImage") or "lightningacr.azurecr.io/worker-task:latest"
 
 # Resource group
 resource_group = resources.ResourceGroup(


### PR DESCRIPTION
## Summary
- use a plain string for the default worker image

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'Request' from 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_683c58ee8e08832e882ff862a92facf1