### PR TITLE
Add password strength checks and security docs

### DIFF
--- a/AUTH_SYSTEM_GUIDE.md
+++ b/AUTH_SYSTEM_GUIDE.md
@@ -170,9 +170,10 @@ python test_auth_flow.py
 - **Admin Verification**: Token-based admin endpoint protection
 
 ### Input Validation
-- **Password Requirements**: Minimum 6 characters
+- **Password Requirements**: Minimum 8 characters with letters and numbers
 - **Email Validation**: Optional but validated if provided
 - **CSRF Protection**: Session-based request validation
+- **Rate Limiting**: Basic per-IP throttling
 
 ## Monitoring & Logging
 

--- a/azure-function/UserAuth/__init__.py
+++ b/azure-function/UserAuth/__init__.py
@@ -24,12 +24,26 @@ def _hash_password(password: str, salt: str) -> str:
     return hashlib.sha256((salt + password).encode("utf-8")).hexdigest()
 
 
+def _is_strong_password(password: str) -> bool:
+    if len(password) < 8:
+        return False
+    has_letter = any(c.isalpha() for c in password)
+    has_digit = any(c.isdigit() for c in password)
+    return has_letter and has_digit
+
+
 def _register(data: dict) -> func.HttpResponse:
     username = data.get("username")
     password = data.get("password")
     email = data.get("email", "")
     if not username or not password:
         return func.HttpResponse("Missing credentials", status_code=400)
+
+    if not _is_strong_password(password):
+        return func.HttpResponse(
+            "Password must be at least 8 characters and include letters and numbers",
+            status_code=400,
+        )
     try:
         existing_user = _container.read_item("user", partition_key=username)
         return func.HttpResponse("Username exists", status_code=409)

--- a/chat_client/auth_app.py
+++ b/chat_client/auth_app.py
@@ -6,6 +6,9 @@ Users must authenticate before accessing the Chainlit chat interface.
 
 import os
 import logging
+import secrets
+import time
+from collections import defaultdict, deque
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -29,6 +32,44 @@ templates = Jinja2Templates(directory="templates")
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+# Simple in-memory rate limiting
+RATE_LIMIT_WINDOW = 60  # seconds
+RATE_LIMIT_MAX = 10
+_rate_limit: dict[str, deque] = defaultdict(deque)
+
+CSRF_SESSION_KEY = "csrf_token"
+
+
+def _is_rate_limited(ip: str) -> bool:
+    now = time.time()
+    window = _rate_limit[ip]
+    while window and window[0] < now - RATE_LIMIT_WINDOW:
+        window.popleft()
+    if len(window) >= RATE_LIMIT_MAX:
+        return True
+    window.append(now)
+    return False
+
+
+def _generate_csrf_token(request: Request) -> str:
+    token = secrets.token_hex(16)
+    request.session[CSRF_SESSION_KEY] = token
+    return token
+
+
+def _verify_csrf(request: Request, token: str) -> None:
+    expected = request.session.get(CSRF_SESSION_KEY)
+    if not expected or expected != token:
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+
+def _is_strong_password(password: str) -> bool:
+    if len(password) < 8:
+        return False
+    has_letter = any(c.isalpha() for c in password)
+    has_digit = any(c.isdigit() for c in password)
+    return has_letter and has_digit
 
 
 def verify_token(token: str) -> Optional[str]:
@@ -71,10 +112,13 @@ async def login_page(request: Request, username: Optional[str] = Depends(get_cur
     """Display login page or redirect to chat if already authenticated."""
     if username:
         return RedirectResponse(url="/chat", status_code=302)
-    
+
+    csrf_token = _generate_csrf_token(request)
+
     return templates.TemplateResponse("login.html", {
         "request": request,
-        "error": request.query_params.get("error")
+        "error": request.query_params.get("error"),
+        "csrf_token": csrf_token,
     })
 
 
@@ -82,11 +126,18 @@ async def login_page(request: Request, username: Optional[str] = Depends(get_cur
 async def login(
     request: Request,
     username: str = Form(...),
-    password: str = Form(...)
+    password: str = Form(...),
+    csrf_token: str = Form(default="")
 ):
     """Handle user login."""
     if not AUTH_API_URL:
         raise HTTPException(status_code=500, detail="Authentication service not configured")
+
+    client_ip = request.client.host if request.client else "unknown"
+    if _is_rate_limited(client_ip):
+        raise HTTPException(status_code=429, detail="Too many requests")
+
+    _verify_csrf(request, csrf_token)
     
     try:
         # Call Azure Function auth endpoint
@@ -144,9 +195,11 @@ async def login(
 @app.get("/register", response_class=HTMLResponse)
 async def register_page(request: Request):
     """Display registration page."""
+    csrf_token = _generate_csrf_token(request)
     return templates.TemplateResponse("register.html", {
         "request": request,
-        "error": request.query_params.get("error")
+        "error": request.query_params.get("error"),
+        "csrf_token": csrf_token,
     })
 
 
@@ -156,16 +209,23 @@ async def register(
     username: str = Form(...),
     password: str = Form(...),
     confirm_password: str = Form(...),
-    email: str = Form(default="")
+    email: str = Form(default=""),
+    csrf_token: str = Form(default="")
 ):
     """Handle user registration."""
     if not AUTH_API_URL:
         raise HTTPException(status_code=500, detail="Authentication service not configured")
+
+    client_ip = request.client.host if request.client else "unknown"
+    if _is_rate_limited(client_ip):
+        raise HTTPException(status_code=429, detail="Too many requests")
+
+    _verify_csrf(request, csrf_token)
     
     if password != confirm_password:
         return RedirectResponse(url="/register?error=password_mismatch", status_code=302)
     
-    if len(password) < 6:
+    if not _is_strong_password(password):
         return RedirectResponse(url="/register?error=password_too_short", status_code=302)
     
     try:

--- a/tests/test_user_auth.py
+++ b/tests/test_user_auth.py
@@ -23,6 +23,9 @@ def load_user_auth(monkeypatch, store, token_capture):
                 raise ValueError('no body')
             return json.loads(self._body)
 
+        def get_body(self):
+            return self._body.encode() if isinstance(self._body, str) else self._body
+
     class DummyResponse:
         def __init__(self, body='', status_code=200, mimetype=None):
             self.body = body
@@ -92,12 +95,12 @@ def test_register_success(monkeypatch):
     cap = {}
     mod, Request = load_user_auth(monkeypatch, store, cap)
 
-    req = Request(body=json.dumps({'username': 'alice', 'password': 'pw'}))
+    req = Request(body=json.dumps({'username': 'alice', 'password': 'Password1'}))
     req.route_params = {'action': 'register'}
     resp = mod.main(req)
     assert resp.status_code == 201
     assert ('alice', 'user') in store
-    assert store[('alice', 'user')]['hash'] != 'pw'
+    assert store[('alice', 'user')]['hash'] != 'Password1'
 
 
 def test_register_duplicate(monkeypatch):
@@ -105,11 +108,11 @@ def test_register_duplicate(monkeypatch):
     os.environ['USER_CONTAINER'] = 'users'
     os.environ['JWT_SIGNING_KEY'] = 'k'
     salt = 's'
-    store = {('bob', 'user'): {'pk': 'bob', 'id': 'user', 'salt': salt, 'hash': hashlib.sha256((salt + 'pw').encode()).hexdigest()}}
+    store = {('bob', 'user'): {'pk': 'bob', 'id': 'user', 'salt': salt, 'hash': hashlib.sha256((salt + 'Password1').encode()).hexdigest(), 'status': 'approved'}}
     cap = {}
     mod, Request = load_user_auth(monkeypatch, store, cap)
 
-    req = Request(body=json.dumps({'username': 'bob', 'password': 'pw'}))
+    req = Request(body=json.dumps({'username': 'bob', 'password': 'Password1'}))
     req.route_params = {'action': 'register'}
     resp = mod.main(req)
     assert resp.status_code == 409
@@ -120,12 +123,12 @@ def test_login_success(monkeypatch):
     os.environ['USER_CONTAINER'] = 'users'
     os.environ['JWT_SIGNING_KEY'] = 'k'
     salt = 's'
-    hashed = hashlib.sha256((salt + 'pw').encode()).hexdigest()
-    store = {('bob', 'user'): {'pk': 'bob', 'id': 'user', 'salt': salt, 'hash': hashed}}
+    hashed = hashlib.sha256((salt + 'Password1').encode()).hexdigest()
+    store = {('bob', 'user'): {'pk': 'bob', 'id': 'user', 'salt': salt, 'hash': hashed, 'status': 'approved'}}
     capture = {}
     mod, Request = load_user_auth(monkeypatch, store, capture)
 
-    req = Request(body=json.dumps({'username': 'bob', 'password': 'pw'}))
+    req = Request(body=json.dumps({'username': 'bob', 'password': 'Password1'}))
     req.route_params = {'action': 'login'}
     resp = mod.main(req)
     assert resp.status_code == 200
@@ -139,8 +142,8 @@ def test_login_bad_password(monkeypatch):
     os.environ['USER_CONTAINER'] = 'users'
     os.environ['JWT_SIGNING_KEY'] = 'k'
     salt = 's'
-    hashed = hashlib.sha256((salt + 'pw').encode()).hexdigest()
-    store = {('bob', 'user'): {'pk': 'bob', 'id': 'user', 'salt': salt, 'hash': hashed}}
+    hashed = hashlib.sha256((salt + 'Password1').encode()).hexdigest()
+    store = {('bob', 'user'): {'pk': 'bob', 'id': 'user', 'salt': salt, 'hash': hashed, 'status': 'approved'}}
     cap = {}
     mod, Request = load_user_auth(monkeypatch, store, cap)
 
@@ -148,4 +151,18 @@ def test_login_bad_password(monkeypatch):
     req.route_params = {'action': 'login'}
     resp = mod.main(req)
     assert resp.status_code == 401
+
+
+def test_register_weak_password(monkeypatch):
+    os.environ['COSMOS_CONNECTION'] = 'c'
+    os.environ['USER_CONTAINER'] = 'users'
+    os.environ['JWT_SIGNING_KEY'] = 'k'
+    store = {}
+    cap = {}
+    mod, Request = load_user_auth(monkeypatch, store, cap)
+
+    req = Request(body=json.dumps({'username': 'weak', 'password': 'short'}))
+    req.route_params = {'action': 'register'}
+    resp = mod.main(req)
+    assert resp.status_code == 400
 


### PR DESCRIPTION
## Summary
- strengthen password checks in Azure Function UserAuth
- add simple rate limiting and CSRF helpers in `auth_app`
- check password complexity in registration API
- document new requirements in AUTH_SYSTEM_GUIDE
- update tests for new password policy

## Testing
- `pytest tests/test_user_auth.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'Request' from 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_683c59b5f3f8832e842d349cbb173a6a