### PR TITLE
Add JWT refresh endpoint and client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ curl -X POST \
 The returned token should be provided in the `Authorization` header when calling
 the other API endpoints.
 
+### POST /api/refresh
+
+Send the current token in the `Authorization` header to obtain a new JWT with a
+fresh expiration time:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <token>" \
+  https://<function-app>.azurewebsites.net/api/refresh
+```
+
+If the token is valid a new token is returned. Invalid or expired tokens result
+in a `401` response.
+
 ## Python library
 
 The `events` package provides a dataclass `Event` that can be used to structure events before they are sent to the API or processed downstream.


### PR DESCRIPTION
## Summary
- extend UserAuth function with `/refresh` action
- auto-refresh auth tokens in the chat client
- document the refresh endpoint
- test token refresh logic

## Testing
- `pytest -q` *(fails: fixture 'session' not found; AttributeError in chainlit_app; assertion failing in user auth login)*

------
https://chatgpt.com/codex/tasks/task_e_683c63917eac832eb47a22a40c1a7b03