### PR TITLE
Rename resource group to lightning_dev

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -27,8 +27,8 @@ worker_image = config.get("workerImage") or "lightningacr.azurecr.io/worker-task
 
 # Resource group
 resource_group = resources.ResourceGroup(
-    "lightning",
-    resource_group_name="lightning",
+    "lightning_dev",
+    resource_group_name="lightning_dev",
     location=location,
 )
 


### PR DESCRIPTION
## Summary
- rename the resource group to `lightning_dev` in Pulumi stack

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c71423780832eb5e7b60357ae84fd