### PR TITLE
Track OpenAI usage & cost

### DIFF
--- a/azure-function/ChatResponder/__init__.py
+++ b/azure-function/ChatResponder/__init__.py
@@ -43,6 +43,7 @@ def main(msg: func.ServiceBusMessage) -> None:
             model=OPENAI_MODEL,
         )
         reply = response["choices"][0]["message"]["content"]
+        usage = response.get("usage")
         logging.info("Assistant reply: %s", reply)
     except Exception as e:
         logging.error("ChatCompletion failed: %s", e)
@@ -53,7 +54,7 @@ def main(msg: func.ServiceBusMessage) -> None:
         source="ChatResponder",
         type="llm.chat.response",
         user_id=event.user_id,
-        metadata={"reply": reply},
+        metadata={"reply": reply, "usage": usage},
         history=event.history + [event.to_dict()],
     )
 
@@ -67,4 +68,3 @@ def main(msg: func.ServiceBusMessage) -> None:
                 sender.send_messages(message)
     except Exception as e:
         logging.error("Failed to publish response: %s", e)
-

--- a/azure-function/WorkerTaskRunner/__init__.py
+++ b/azure-function/WorkerTaskRunner/__init__.py
@@ -90,16 +90,25 @@ def main(msg: func.ServiceBusMessage) -> None:
         if not _aci_client:
             raise RuntimeError("ACI client not configured")
         env_list = [
-            EnvironmentVariable(name="SERVICEBUS_CONNECTION", value=SERVICEBUS_CONN or ""),
+            EnvironmentVariable(
+                name="SERVICEBUS_CONNECTION", value=SERVICEBUS_CONN or ""
+            ),
             EnvironmentVariable(name="SERVICEBUS_QUEUE", value=SERVICEBUS_QUEUE or ""),
             EnvironmentVariable(name="WORKER_EVENT", value=json.dumps(event.to_dict())),
             EnvironmentVariable(name="TASK_ID", value=task_id),
-            EnvironmentVariable(name="OPENAI_API_KEY", value=os.environ.get("OPENAI_API_KEY", "")),
+            EnvironmentVariable(
+                name="OPENAI_API_KEY", value=os.environ.get("OPENAI_API_KEY", "")
+            ),
+            EnvironmentVariable(name="COSMOS_CONNECTION", value=COSMOS_CONN or ""),
+            EnvironmentVariable(name="COSMOS_DATABASE", value=COSMOS_DB),
+            EnvironmentVariable(name="TASK_CONTAINER", value=TASK_CONTAINER),
         ]
         container = Container(
             name="worker",
             image=WORKER_IMAGE,
-            resources=ResourceRequirements(requests=ResourceRequests(cpu=1.0, memory_in_gb=1.0)),
+            resources=ResourceRequirements(
+                requests=ResourceRequests(cpu=1.0, memory_in_gb=1.0)
+            ),
             environment_variables=env_list,
         )
         group = ContainerGroup(

--- a/dashboard/templates/tasks.html
+++ b/dashboard/templates/tasks.html
@@ -12,11 +12,17 @@
             const tasks = await resp.json();
             const tbody = document.getElementById('tasks-body');
             tbody.innerHTML = '';
+            let total = 0;
             tasks.forEach(t => {
                 const row = document.createElement('tr');
-                row.innerHTML = `<td>${t.id}</td><td>${t.status}</td><td><button onclick="showLogs('${t.id}')">view</button></td>`;
+                const info = t.cost || {};
+                const cost = info.cost ? Number(info.cost) : 0;
+                total += cost;
+                const costDisplay = cost ? '$' + cost.toFixed(4) : '';
+                row.innerHTML = `<td>${t.id}</td><td>${t.status}</td><td>${costDisplay}</td><td><button onclick="showLogs('${t.id}')">view</button></td>`;
                 tbody.appendChild(row);
             });
+            document.getElementById('total-cost').textContent = '$' + total.toFixed(4);
         }
         let logInterval;
         async function showLogs(id) {
@@ -40,9 +46,10 @@
     <h1>Task Monitor</h1>
     <p id="error" style="color:red"></p>
     <table border="1">
-        <thead><tr><th>ID</th><th>Status</th><th>Logs</th></tr></thead>
+        <thead><tr><th>ID</th><th>Status</th><th>Cost</th><th>Logs</th></tr></thead>
         <tbody id="tasks-body"></tbody>
     </table>
+    <p>Total cost: <span id="total-cost">$0.0000</span></p>
     <pre id="logs" style="background:#f0f0f0;padding:1em;"></pre>
 </body>
 </html>

--- a/events/__init__.py
+++ b/events/__init__.py
@@ -96,6 +96,7 @@ class WorkerTaskEvent(Event):
     commands: List[str] = field(default_factory=list)
     task: Optional[str] = None
     repo_url: Optional[str] = None
+    cost: Optional[Dict[str, Any]] = None
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "WorkerTaskEvent":
@@ -105,7 +106,16 @@ class WorkerTaskEvent(Event):
         if not cmds and not task:
             raise ValueError("metadata.commands or metadata.task required")
         repo = base.metadata.get("repo_url")
-        return cls(**asdict(base), commands=cmds, task=task, repo_url=repo)
+        cost = base.metadata.get("cost")
+        if cost is not None and not isinstance(cost, dict):
+            cost = {"cost": float(cost)}
+        return cls(
+            **asdict(base),
+            commands=cmds,
+            task=task,
+            repo_url=repo,
+            cost=cost,
+        )
 
     def to_dict(self) -> Dict[str, Any]:
         d = super().to_dict()
@@ -116,5 +126,7 @@ class WorkerTaskEvent(Event):
             meta["task"] = self.task
         if self.repo_url is not None:
             meta["repo_url"] = self.repo_url
+        if self.cost is not None:
+            meta["cost"] = self.cost
         d["metadata"] = meta
         return d

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,81 +1,86 @@
 import sys, os, types, subprocess, pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from agents import AGENT_REGISTRY
 
 
 def test_echo_agent_registry():
-    assert 'echo' in AGENT_REGISTRY
-    agent = AGENT_REGISTRY['echo']
-    result = agent.run(['hi', 'there'])
-    assert result == 'hi\nthere'
+    assert "echo" in AGENT_REGISTRY
+    agent = AGENT_REGISTRY["echo"]
+    result = agent.run(["hi", "there"])
+    assert result == "hi\nthere"
 
 
 def test_openai_shell_agent(monkeypatch, capsys):
-    assert 'openai-shell' in AGENT_REGISTRY
-    agent = AGENT_REGISTRY['openai-shell']
+    assert "openai-shell" in AGENT_REGISTRY
+    agent = AGENT_REGISTRY["openai-shell"]
 
     captured = {}
 
     class ChatStub:
         @staticmethod
         def create(messages=None, model=None, tools=None, tool_choice=None):
-            captured['messages'] = messages
-            captured['model'] = model
-            captured['tools'] = tools
-            captured['tool_choice'] = tool_choice
+            captured["messages"] = messages
+            captured["model"] = model
+            captured["tools"] = tools
+            captured["tool_choice"] = tool_choice
             return {
                 "choices": [
                     {
                         "message": {
                             "tool_calls": [
-                                {
-                                    "function": {
-                                        "arguments": '{"command": "echo hello"}'
-                                    }
-                                }
+                                {"function": {"arguments": '{"command": "echo hello"}'}}
                             ]
                         }
                     }
-                ]
+                ],
+                "usage": {"total_tokens": 5},
             }
 
     openai_stub = types.SimpleNamespace(ChatCompletion=ChatStub)
-    monkeypatch.setitem(sys.modules, 'openai', openai_stub)
-    def stub_run(cmd, shell=False, capture_output=False, text=False):
-        captured['cmd'] = cmd
-        return types.SimpleNamespace(stdout='hello\n', stderr='')
-    monkeypatch.setattr(subprocess, 'run', stub_run)
-    monkeypatch.setenv('OPENAI_API_KEY', 'sk')
-    monkeypatch.setenv('OPENAI_MODEL', 'model-test')
+    monkeypatch.setitem(sys.modules, "openai", openai_stub)
 
-    result = agent.run('say hello')
+    def stub_run(cmd, shell=False, capture_output=False, text=False):
+        captured["cmd"] = cmd
+        return types.SimpleNamespace(stdout="hello\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", stub_run)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setenv("OPENAI_MODEL", "model-test")
+
+    result = agent.run("say hello")
     out = capsys.readouterr().out
-    assert '$ echo hello' in out
-    assert 'hello' in out
-    assert 'hello' in result
-    assert captured['model'] == 'model-test'
-    assert captured['tools'][0]['function']['name'] == 'bash'
+    assert "$ echo hello" in out
+    assert "hello" in out
+    assert "hello" in result
+    assert captured["model"] == "model-test"
+    assert captured["tools"][0]["function"]["name"] == "bash"
+    assert agent.last_usage["total_tokens"] == 5
 
 
 def test_openai_shell_missing_api_key(monkeypatch):
-    agent = AGENT_REGISTRY['openai-shell']
-    openai_stub = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=lambda **k: {"choices": []}))
-    monkeypatch.setitem(sys.modules, 'openai', openai_stub)
-    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    agent = AGENT_REGISTRY["openai-shell"]
+    openai_stub = types.SimpleNamespace(
+        ChatCompletion=types.SimpleNamespace(create=lambda **k: {"choices": []})
+    )
+    monkeypatch.setitem(sys.modules, "openai", openai_stub)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     with pytest.raises(RuntimeError):
-        agent.run('cmd')
+        agent.run("cmd")
 
 
 def test_openai_shell_missing_library(monkeypatch):
-    agent = AGENT_REGISTRY['openai-shell']
-    monkeypatch.setenv('OPENAI_API_KEY', 'sk')
+    agent = AGENT_REGISTRY["openai-shell"]
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
     import builtins as _builtins
+
     orig_import = _builtins.__import__
+
     def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == 'openai':
+        if name == "openai":
             raise ModuleNotFoundError
         return orig_import(name, globals, locals, fromlist, level)
-    monkeypatch.setattr(_builtins, '__import__', fake_import)
+
+    monkeypatch.setattr(_builtins, "__import__", fake_import)
     with pytest.raises(RuntimeError):
-        agent.run('cmd')
+        agent.run("cmd")

--- a/tests/test_chat_responder.py
+++ b/tests/test_chat_responder.py
@@ -10,70 +10,93 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 def load_chat_responder(monkeypatch, capture):
     # stub openai module
-    openai_stub = types.ModuleType('openai')
+    openai_stub = types.ModuleType("openai")
+
     class ChatStub:
         @staticmethod
         def create(messages=None, model=None):
-            capture['model'] = model
-            return {"choices": [{"message": {"content": "ok"}}]}
+            capture["model"] = model
+            return {
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {"total_tokens": 7},
+            }
+
     openai_stub.ChatCompletion = ChatStub
-    monkeypatch.setitem(sys.modules, 'openai', openai_stub)
+    monkeypatch.setitem(sys.modules, "openai", openai_stub)
 
     # stub azure functions
-    azure_mod = types.ModuleType('azure')
-    func_mod = types.ModuleType('functions')
+    azure_mod = types.ModuleType("azure")
+    func_mod = types.ModuleType("functions")
+
     class DummySBMessage:
         def __init__(self, body):
-            self._body = body.encode('utf-8')
+            self._body = body.encode("utf-8")
+
         def get_body(self):
             return self._body
+
     func_mod.ServiceBusMessage = DummySBMessage
     azure_mod.functions = func_mod
 
-    sb_mod = types.ModuleType('servicebus')
+    sb_mod = types.ModuleType("servicebus")
+
     class DummySender:
         def __enter__(self):
             return self
+
         def __exit__(self, exc_type, exc, tb):
             pass
+
         def send_messages(self, msg):
-            pass
+            capture["out"] = json.loads(msg.body)
+
     class DummyClient:
         def __enter__(self):
             return self
+
         def __exit__(self, exc_type, exc, tb):
             pass
+
         def get_queue_sender(self, queue_name=None):
             return DummySender()
+
     sb_mod.ServiceBusClient = types.SimpleNamespace(
         from_connection_string=lambda *a, **k: DummyClient()
     )
+
     class DummyOutMessage:
         def __init__(self, body):
             self.body = body
             self.application_properties = {}
+
     sb_mod.ServiceBusMessage = DummyOutMessage
     azure_mod.servicebus = sb_mod
 
-    monkeypatch.setitem(sys.modules, 'azure', azure_mod)
-    monkeypatch.setitem(sys.modules, 'azure.functions', func_mod)
-    monkeypatch.setitem(sys.modules, 'azure.servicebus', sb_mod)
+    monkeypatch.setitem(sys.modules, "azure", azure_mod)
+    monkeypatch.setitem(sys.modules, "azure.functions", func_mod)
+    monkeypatch.setitem(sys.modules, "azure.servicebus", sb_mod)
 
     spec = importlib.util.spec_from_file_location(
-        'ChatResponder',
-        os.path.join(os.path.dirname(__file__), '..', 'azure-function', 'ChatResponder', '__init__.py')
+        "ChatResponder",
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "azure-function",
+            "ChatResponder",
+            "__init__.py",
+        ),
     )
     module = importlib.util.module_from_spec(spec)
-    sys.modules['ChatResponder'] = module
+    sys.modules["ChatResponder"] = module
     spec.loader.exec_module(module)
     return module, func_mod.ServiceBusMessage
 
 
 def test_openai_model_env(monkeypatch):
-    os.environ['SERVICEBUS_CONNECTION'] = 'endpoint'
-    os.environ['SERVICEBUS_QUEUE'] = 'queue'
-    os.environ['OPENAI_MODEL'] = 'test-model'
-    os.environ['OPENAI_API_KEY'] = 'sk-test'
+    os.environ["SERVICEBUS_CONNECTION"] = "endpoint"
+    os.environ["SERVICEBUS_QUEUE"] = "queue"
+    os.environ["OPENAI_MODEL"] = "test-model"
+    os.environ["OPENAI_API_KEY"] = "sk-test"
 
     captured = {}
     module, SBMessage = load_chat_responder(monkeypatch, captured)
@@ -88,14 +111,15 @@ def test_openai_model_env(monkeypatch):
     msg = SBMessage(json.dumps(event))
     module.main(msg)
 
-    assert captured['model'] == 'test-model'
+    assert captured["model"] == "test-model"
+    assert captured["out"]["metadata"]["usage"]["total_tokens"] == 7
 
 
 def test_missing_api_key(monkeypatch):
-    os.environ['SERVICEBUS_CONNECTION'] = 'endpoint'
-    os.environ['SERVICEBUS_QUEUE'] = 'queue'
-    if 'OPENAI_API_KEY' in os.environ:
-        del os.environ['OPENAI_API_KEY']
+    os.environ["SERVICEBUS_CONNECTION"] = "endpoint"
+    os.environ["SERVICEBUS_QUEUE"] = "queue"
+    if "OPENAI_API_KEY" in os.environ:
+        del os.environ["OPENAI_API_KEY"]
 
     with pytest.raises(RuntimeError):
         load_chat_responder(monkeypatch, {})

--- a/tests/test_worker_main.py
+++ b/tests/test_worker_main.py
@@ -2,9 +2,10 @@ import os
 import sys
 import json
 import importlib
+import types
 from datetime import datetime
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from events import WorkerTaskEvent
 
@@ -15,11 +16,43 @@ def test_worker_main_runs_agent(monkeypatch, capsys):
 
     class DummyAgent(Agent):
         name = "openai-shell"
+
         def run(self, commands):
             assert commands == "do stuff"
+            self.last_usage = {"total_tokens": 100}
             return "ok"
 
     AGENT_REGISTRY["openai-shell"] = DummyAgent()
+
+    # stub cosmos client
+    cosmos_mod = types.ModuleType("cosmos")
+
+    class DummyContainer:
+        def __init__(self):
+            self.updated = None
+
+        def create_container_if_not_exists(self, *a, **k):
+            return self
+
+        def create_database_if_not_exists(self, *a, **k):
+            return self
+
+        def upsert_item(self, item):
+            self.updated = item
+
+        def read_item(self, item, partition_key=None):
+            return {}
+
+    dummy_container = DummyContainer()
+    cosmos_mod.CosmosClient = types.SimpleNamespace(
+        from_connection_string=lambda *a, **k: dummy_container
+    )
+    cosmos_mod.PartitionKey = lambda path: {"path": path}
+    monkeypatch.setitem(sys.modules, "azure.cosmos", cosmos_mod)
+    os.environ["COSMOS_CONNECTION"] = "conn"
+    os.environ["COSMOS_DATABASE"] = "db"
+    os.environ["TASK_CONTAINER"] = "tasks"
+    os.environ["TASK_ID"] = "t1"
 
     event = WorkerTaskEvent(
         timestamp=datetime.utcnow(),
@@ -27,7 +60,7 @@ def test_worker_main_runs_agent(monkeypatch, capsys):
         type="worker.task",
         user_id="u1",
         metadata={},
-        task="do stuff"
+        task="do stuff",
     )
     os.environ["WORKER_EVENT"] = json.dumps(event.to_dict())
 
@@ -36,4 +69,8 @@ def test_worker_main_runs_agent(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "ok" in captured.out
-
+    info = dummy_container.updated["cost"]
+    assert abs(info["cost"] - 0.0002) < 1e-6
+    assert info["tokens"] == 100
+    assert info["event_count"] == 1
+    assert info["runtime_sec"] >= 0

--- a/tests/test_worker_task_event.py
+++ b/tests/test_worker_task_event.py
@@ -37,6 +37,7 @@ def test_worker_task_round_trip():
     assert out["metadata"]["repo_url"] == "https://example.com/repo.git"
     assert out["history"] == []
 
+
 def test_worker_task_with_task():
     now = datetime.now()
     data = {
@@ -50,3 +51,18 @@ def test_worker_task_with_task():
     assert event.task == "run tests"
     out = event.to_dict()
     assert out["metadata"]["task"] == "run tests"
+
+
+def test_worker_task_with_cost():
+    now = datetime.now()
+    data = {
+        "timestamp": now.isoformat(),
+        "source": "s",
+        "type": "worker.task",
+        "userID": "u1",
+        "metadata": {"commands": ["echo"], "cost": {"cost": 0.5, "tokens": 5}},
+    }
+    event = WorkerTaskEvent.from_dict(data)
+    assert event.cost["cost"] == 0.5
+    out = event.to_dict()
+    assert out["metadata"]["cost"]["tokens"] == 5

--- a/worker.py
+++ b/worker.py
@@ -1,6 +1,10 @@
 import json
 import os
 import sys
+from datetime import datetime
+import time
+
+from azure.cosmos import CosmosClient, PartitionKey
 
 from agents import AGENT_REGISTRY
 from events import WorkerTaskEvent
@@ -24,10 +28,43 @@ def main() -> int:
         print(f"Unknown agent: {agent_name}", file=sys.stderr)
         return 1
 
+    start_time = time.time()
     if event.task:
         result = agent.run(event.task)
     else:
         result = agent.run(event.commands)
+    runtime = time.time() - start_time
+
+    usage = getattr(agent, "last_usage", {}) or {}
+    tokens = usage.get("total_tokens", 0)
+    model = os.environ.get("OPENAI_MODEL", "gpt-3.5-turbo")
+    cost_rate = float(os.environ.get("OPENAI_PRICE_PER_1K_TOKENS", "0.002")) / 1000
+    cost_usd = tokens * cost_rate
+    event.cost = {
+        "cost": cost_usd,
+        "tokens": tokens,
+        "model": model,
+        "runtime_sec": runtime,
+        "event_count": len(event.history) + 1,
+    }
+
+    cosmos_conn = os.environ.get("COSMOS_CONNECTION")
+    task_id = os.environ.get("TASK_ID")
+    if cosmos_conn and task_id:
+        db_name = os.environ.get("COSMOS_DATABASE", "lightning")
+        container_name = os.environ.get("TASK_CONTAINER", "tasks")
+        client = CosmosClient.from_connection_string(cosmos_conn)
+        db = client.create_database_if_not_exists(db_name)
+        container = db.create_container_if_not_exists(
+            id=container_name, partition_key=PartitionKey(path="/pk")
+        )
+        try:
+            item = container.read_item(task_id, partition_key=event.user_id)
+        except Exception:
+            item = {"id": task_id, "pk": event.user_id}
+        item["cost"] = event.cost
+        item["updated_at"] = datetime.utcnow().isoformat()
+        container.upsert_item(item)
 
     if result:
         print(result)


### PR DESCRIPTION
## Summary
- capture token usage in `ChatResponder` and `openai_shell_agent`
- extend `WorkerTaskEvent` with optional cost field
- compute cost and store it in Cosmos from `worker.py`
- pass Cosmos DB parameters to worker container
- show task costs on the dashboard
- update unit tests for new usage and cost behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c7153f1f8832e92fe9feb84a274e9