### PR TITLE
Add Application Insights to Pulumi stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ messaging:
 - `REPO_CONTAINER` &mdash; container storing repository URLs. Defaults to `repos`.
 - `SCHEDULE_CONTAINER` &mdash; container used by the scheduler. Defaults to `schedules`.
 - `TASK_CONTAINER` &mdash; container storing worker task records. Defaults to `tasks`.
+- `APPINSIGHTS_INSTRUMENTATIONKEY` &mdash; instrumentation key for Application Insights. Pulumi sets this automatically.
 - `WEBSITE_RUN_FROM_PACKAGE` &mdash; URL of the function package including a SAS
   token. The Function App cannot start without this token. Pulumi populates this
   value automatically.


### PR DESCRIPTION
## Summary
- create Log Analytics workspace and Application Insights component
- export instrumentation key and configure Function App
- pass key to Chainlit UI container
- document new environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d61c7533c832ea99865d366fadfef