### PR TITLE
Add Cosmos-backed policy management

### DIFF
--- a/azure-function/PolicyManager/__init__.py
+++ b/azure-function/PolicyManager/__init__.py
@@ -1,0 +1,46 @@
+import json
+import os
+
+import azure.functions as func
+from azure.cosmos import CosmosClient, PartitionKey
+
+from auth import verify_token
+
+COSMOS_CONN = os.environ.get("COSMOS_CONNECTION")
+COSMOS_DB = os.environ.get("COSMOS_DATABASE", "lightning")
+POLICY_CONTAINER = os.environ.get("POLICY_CONTAINER", "policies")
+
+_client = CosmosClient.from_connection_string(COSMOS_CONN)
+_db = _client.create_database_if_not_exists(COSMOS_DB)
+_container = _db.create_container_if_not_exists(
+    id=POLICY_CONTAINER, partition_key=PartitionKey(path="/pk")
+)
+
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    try:
+        user_id = verify_token(req.headers.get("Authorization"))
+    except Exception:
+        return func.HttpResponse("Unauthorized", status_code=401)
+
+    if req.method == "GET":
+        try:
+            entity = _container.read_item("policy", partition_key=user_id)
+            policy = entity.get("policy", {})
+        except Exception:
+            policy = {}
+        return func.HttpResponse(json.dumps(policy), status_code=200, mimetype="application/json")
+
+    if req.method in ["POST", "PUT"]:
+        try:
+            data = req.get_json()
+        except ValueError:
+            return func.HttpResponse("Invalid JSON", status_code=400)
+        entity = {"id": "policy", "pk": user_id, "policy": data}
+        try:
+            _container.upsert_item(entity)
+        except Exception:
+            return func.HttpResponse("Failed", status_code=500)
+        return func.HttpResponse("ok", status_code=200)
+
+    return func.HttpResponse("Method not allowed", status_code=405)

--- a/azure-function/WorkerTaskRunner/__init__.py
+++ b/azure-function/WorkerTaskRunner/__init__.py
@@ -95,6 +95,10 @@ def main(msg: func.ServiceBusMessage) -> None:
             EnvironmentVariable(name="WORKER_EVENT", value=json.dumps(event.to_dict())),
             EnvironmentVariable(name="TASK_ID", value=task_id),
             EnvironmentVariable(name="OPENAI_API_KEY", value=os.environ.get("OPENAI_API_KEY", "")),
+            EnvironmentVariable(name="COSMOS_CONNECTION", value=COSMOS_CONN or ""),
+            EnvironmentVariable(name="COSMOS_DATABASE", value=COSMOS_DB or ""),
+            EnvironmentVariable(name="POLICY_CONTAINER", value=os.environ.get("POLICY_CONTAINER", "policies")),
+            EnvironmentVariable(name="USER_ID", value=event.user_id),
         ]
         container = Container(
             name="worker",

--- a/policy.py
+++ b/policy.py
@@ -1,0 +1,102 @@
+import json
+import json
+import os
+from typing import Dict, List
+
+try:
+    from azure.cosmos import CosmosClient, PartitionKey  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    CosmosClient = None  # type: ignore
+    PartitionKey = None  # type: ignore
+
+__all__ = ["PolicyViolationError", "get_policy_prompt", "validate_command"]
+
+
+class PolicyViolationError(RuntimeError):
+    """Raised when a command violates the active security policy."""
+
+
+_policies: Dict[str, List[str]] = {}
+_prompt: str = ""
+_current_file: str | None = None
+_current_user: str | None = None
+
+_cosmos_client = None
+_cosmos_container = None
+
+
+def _get_cosmos_container():
+    global _cosmos_client, _cosmos_container
+    if _cosmos_container is not None:
+        return _cosmos_container
+    if CosmosClient is None:
+        return None
+    conn = os.environ.get("COSMOS_CONNECTION")
+    if not conn:
+        return None
+    db_name = os.environ.get("COSMOS_DATABASE", "lightning")
+    container_name = os.environ.get("POLICY_CONTAINER", "policies")
+    _cosmos_client = CosmosClient.from_connection_string(conn)
+    db = _cosmos_client.create_database_if_not_exists(db_name)
+    _cosmos_container = db.create_container_if_not_exists(
+        id=container_name, partition_key=PartitionKey(path="/pk")
+    )
+    return _cosmos_container
+
+
+def _load_policies(force: bool = False) -> None:
+    global _policies, _prompt, _current_file, _current_user
+    user_id = os.environ.get("USER_ID")
+    container = _get_cosmos_container()
+
+    if container and user_id:
+        if not force and _current_user == user_id and _policies:
+            return
+        _current_user = user_id
+        try:
+            entity = container.read_item("policy", partition_key=user_id)
+            data = entity.get("policy", {})
+        except Exception:
+            data = {}
+        patterns = data.get("blocked_patterns")
+        if isinstance(patterns, list):
+            _policies = {"blocked_patterns": [str(p) for p in patterns]}
+        else:
+            _policies = {"blocked_patterns": []}
+        _prompt = str(data.get("prompt", ""))
+        return
+
+    policy_file = os.environ.get("SAFETY_POLICY_FILE")
+    if not force and _current_file == policy_file and _prompt:
+        return
+    _current_file = policy_file
+    if not policy_file:
+        _policies = {"blocked_patterns": []}
+        _prompt = ""
+        return
+    try:
+        with open(policy_file, "r") as f:
+            data = json.load(f)
+    except Exception:
+        _policies = {"blocked_patterns": []}
+        _prompt = ""
+        return
+    patterns = data.get("blocked_patterns")
+    if isinstance(patterns, list):
+        _policies = {"blocked_patterns": [str(p) for p in patterns]}
+    else:
+        _policies = {"blocked_patterns": []}
+    _prompt = str(data.get("prompt", ""))
+
+
+def get_policy_prompt() -> str:
+    _load_policies()
+    return _prompt
+
+
+def validate_command(cmd: str) -> None:
+    """Raise PolicyViolationError if cmd violates the policy."""
+    _load_policies()
+    for pattern in _policies.get("blocked_patterns", []):
+        if pattern and pattern in cmd:
+            raise PolicyViolationError(f"command contains disallowed pattern: {pattern}")

--- a/tests/test_policies_api.py
+++ b/tests/test_policies_api.py
@@ -1,0 +1,99 @@
+import sys
+import json
+import types
+import importlib.util
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+def load_policy_api(monkeypatch, store, token_map=None):
+    azure_mod = types.ModuleType('azure')
+    cosmos_mod = types.ModuleType('cosmos')
+
+    class DummyContainer:
+        def __init__(self):
+            self.store = store
+        def upsert_item(self, item):
+            self.store[(item['pk'], item['id'])] = item
+        def read_item(self, id, partition_key=None):
+            key = (partition_key, id)
+            if key not in self.store:
+                raise Exception('nf')
+            return self.store[key]
+
+    class DummyDatabase:
+        def create_container_if_not_exists(self, *a, **k):
+            return DummyContainer()
+
+    class DummyClient:
+        def create_database_if_not_exists(self, *a, **k):
+            return DummyDatabase()
+
+    cosmos_mod.CosmosClient = types.SimpleNamespace(from_connection_string=lambda *a, **k: DummyClient())
+    cosmos_mod.PartitionKey = lambda path: {'path': path}
+    azure_mod.cosmos = cosmos_mod
+
+    func_mod = types.ModuleType('functions')
+    class DummyRequest:
+        def __init__(self, method='GET', body=None, headers=None, route_params=None):
+            self.method = method
+            self._body = body
+            self.headers = headers or {}
+            self.route_params = route_params or {}
+        def get_json(self):
+            if self._body is None:
+                raise ValueError('no body')
+            return json.loads(self._body)
+    class DummyResponse:
+        def __init__(self, body='', status_code=200, mimetype=None):
+            self.body = body
+            self.status_code = status_code
+            self.mimetype = mimetype
+    func_mod.HttpRequest = DummyRequest
+    func_mod.HttpResponse = DummyResponse
+    azure_mod.functions = func_mod
+
+    auth_mod = types.ModuleType('auth')
+    token_map = token_map or {'Bearer good': 'u1'}
+    def verify_token(header):
+        if header in token_map:
+            return token_map[header]
+        raise Exception('bad')
+    auth_mod.verify_token = verify_token
+
+    monkeypatch.setitem(sys.modules, 'azure', azure_mod)
+    monkeypatch.setitem(sys.modules, 'azure.functions', func_mod)
+    monkeypatch.setitem(sys.modules, 'azure.cosmos', cosmos_mod)
+    monkeypatch.setitem(sys.modules, 'auth', auth_mod)
+
+    spec = importlib.util.spec_from_file_location(
+        'PolicyManager', os.path.join(os.path.dirname(__file__), '..', 'azure-function', 'PolicyManager', '__init__.py')
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['PolicyManager'] = module
+    spec.loader.exec_module(module)
+    return module, DummyRequest
+
+def test_get_policy(monkeypatch):
+    os.environ['COSMOS_CONNECTION'] = 'c'
+    store = {('u1', 'policy'): {'id': 'policy', 'pk': 'u1', 'policy': {'prompt': 'hi'}}}
+    mod, Request = load_policy_api(monkeypatch, store)
+    req = Request(method='GET', headers={'Authorization': 'Bearer good'})
+    resp = mod.main(req)
+    assert resp.status_code == 200
+    data = json.loads(resp.body)
+    assert data['prompt'] == 'hi'
+
+
+def test_update_policy(monkeypatch):
+    os.environ['COSMOS_CONNECTION'] = 'c'
+    store = {}
+    mod, Request = load_policy_api(monkeypatch, store)
+    body = json.dumps({'prompt': 'new', 'blocked_patterns': ['curl']})
+    req = Request(method='PUT', body=body, headers={'Authorization': 'Bearer good'})
+    resp = mod.main(req)
+    assert resp.status_code == 200
+    assert ('u1', 'policy') in store
+    assert store[('u1', 'policy')]['policy']['prompt'] == 'new'

--- a/tests/test_policy_loader.py
+++ b/tests/test_policy_loader.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import json
+import types
+import importlib
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+def load_cosmos(monkeypatch, store):
+    cosmos_mod = types.ModuleType('cosmos')
+
+    class DummyContainer:
+        def __init__(self):
+            self.store = store
+        def read_item(self, id, partition_key=None):
+            key = (partition_key, id)
+            if key not in self.store:
+                raise Exception('nf')
+            return self.store[key]
+        def create_container_if_not_exists(self, *a, **k):
+            return self
+
+    class DummyDatabase:
+        def create_container_if_not_exists(self, *a, **k):
+            return DummyContainer()
+
+    class DummyClient:
+        def create_database_if_not_exists(self, *a, **k):
+            return DummyDatabase()
+
+    cosmos_mod.CosmosClient = types.SimpleNamespace(from_connection_string=lambda *a, **k: DummyClient())
+    cosmos_mod.PartitionKey = lambda path: {'path': path}
+    monkeypatch.setitem(sys.modules, 'azure.cosmos', cosmos_mod)
+
+
+def test_policy_from_cosmos(monkeypatch):
+    store = {('u1', 'policy'): {'id': 'policy', 'pk': 'u1', 'policy': {'prompt': 'hello', 'blocked_patterns': ['curl']}}}
+    load_cosmos(monkeypatch, store)
+    monkeypatch.setenv('COSMOS_CONNECTION', 'c')
+    monkeypatch.setenv('COSMOS_DATABASE', 'd')
+    monkeypatch.setenv('POLICY_CONTAINER', 'policies')
+    monkeypatch.setenv('USER_ID', 'u1')
+    import policy
+    import importlib
+    importlib.reload(policy)
+    assert policy.get_policy_prompt() == 'hello'
+    with pytest.raises(policy.PolicyViolationError):
+        policy.validate_command('curl http://x')

--- a/worker.py
+++ b/worker.py
@@ -2,6 +2,8 @@ import json
 import os
 import sys
 
+from policy import PolicyViolationError
+
 from agents import AGENT_REGISTRY
 from events import WorkerTaskEvent
 
@@ -24,10 +26,14 @@ def main() -> int:
         print(f"Unknown agent: {agent_name}", file=sys.stderr)
         return 1
 
-    if event.task:
-        result = agent.run(event.task)
-    else:
-        result = agent.run(event.commands)
+    try:
+        if event.task:
+            result = agent.run(event.task)
+        else:
+            result = agent.run(event.commands)
+    except PolicyViolationError as e:
+        print(f"Policy violation: {e}", file=sys.stderr)
+        return 1
 
     if result:
         print(result)


### PR DESCRIPTION
## Summary
- read security policy from Cosmos DB with env fallbacks
- pass Cosmos connection info to worker containers
- add HTTP-triggered `PolicyManager` function to get/update policy per user
- test policy retrieval via API and loading policies from Cosmos

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c62c6abf0832e847db6c999f53275