### PR TITLE
Fix GLIBC mismatch in azure function

### DIFF
--- a/azure-function/requirements.txt
+++ b/azure-function/requirements.txt
@@ -7,3 +7,4 @@ croniter
 azure-identity
 azure-mgmt-containerinstance
 pyjwt
+cryptography==41.0.7


### PR DESCRIPTION
## Summary
- pin cryptography to 41.0.7 to avoid requiring GLIBC 2.33 at runtime

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434d368260832e8171f00957d1370a