### PR TITLE
Fix python package build for functions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,12 +12,19 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
       - name: Install dependencies
         run: pip install -r requirements.txt
         working-directory: infra
       - name: Install function dependencies
-        run: pip install -r azure-function/requirements.txt -t azure-function/.python_packages
+        run: |
+          pip install --upgrade pip
+          pip install -r azure-function/requirements.txt \
+            --target azure-function/.python_packages \
+            --platform manylinux2014_x86_64 \
+            --implementation cp \
+            --python-version 3.10 \
+            --only-binary=:all:
       - name: Ensure dev stack exists
         run: pulumi stack select dev --create --non-interactive
         working-directory: infra
@@ -96,12 +103,19 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
       - name: Install dependencies
         run: pip install -r requirements.txt
         working-directory: infra
       - name: Install function dependencies
-        run: pip install -r azure-function/requirements.txt -t azure-function/.python_packages
+        run: |
+          pip install --upgrade pip
+          pip install -r azure-function/requirements.txt \
+            --target azure-function/.python_packages \
+            --platform manylinux2014_x86_64 \
+            --implementation cp \
+            --python-version 3.10 \
+            --only-binary=:all:
       - name: Ensure dev stack exists
         run: pulumi stack select dev --create --non-interactive
         working-directory: infra

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -332,7 +332,23 @@ def create_function_package():
     site_packages = os.path.join(build_dir, ".python_packages", "lib", "site-packages")
     os.makedirs(site_packages, exist_ok=True)
     subprocess.check_call(
-        [sys.executable, "-m", "pip", "install", "-r", "../azure-function/requirements.txt", "--target", site_packages]
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-r",
+            "../azure-function/requirements.txt",
+            "--target",
+            site_packages,
+            "--platform",
+            "manylinux2014_x86_64",
+            "--implementation",
+            "cp",
+            "--python-version",
+            "3.10",
+            "--only-binary=:all:",
+        ]
     )
 
     # Create a temporary ZIP file that persists until cleanup

--- a/scripts/test_azure_functions.py
+++ b/scripts/test_azure_functions.py
@@ -24,6 +24,8 @@ from datetime import datetime, timedelta
 
 import requests
 
+DEFAULT_TIMEOUT = int(os.environ.get("REQUEST_TIMEOUT", "30"))
+
 
 def run(cmd):
     """Run a shell command and return stdout."""
@@ -60,7 +62,7 @@ def register_user(base_url, username, password):
     resp = requests.post(
         f"{base_url}/auth/register",
         json={"username": username, "password": password},
-        timeout=10,
+        timeout=DEFAULT_TIMEOUT,
     )
     print("REGISTER", resp.status_code)
     if resp.status_code != 201 and resp.status_code != 409:
@@ -73,7 +75,7 @@ def approve_user(base_url, username, admin_token):
         f"{base_url}/auth/approve",
         json={"username": username, "action": "approve"},
         headers=headers,
-        timeout=10,
+        timeout=DEFAULT_TIMEOUT,
     )
     print("APPROVE", resp.status_code)
     if resp.status_code != 200:
@@ -84,7 +86,7 @@ def login_user(base_url, username, password):
     resp = requests.post(
         f"{base_url}/auth/login",
         json={"username": username, "password": password},
-        timeout=10,
+        timeout=DEFAULT_TIMEOUT,
     )
     print("LOGIN", resp.status_code)
     if resp.status_code != 200:
@@ -96,7 +98,7 @@ def refresh_token(base_url, token):
     resp = requests.post(
         f"{base_url}/auth/refresh",
         headers={"Authorization": f"Bearer {token}"},
-        timeout=10,
+        timeout=DEFAULT_TIMEOUT,
     )
     print("REFRESH", resp.status_code)
     if resp.status_code != 200:
@@ -115,7 +117,7 @@ def send_event(base_url, token):
         f"{base_url}/events",
         json=event,
         headers={"Authorization": f"Bearer {token}"},
-        timeout=10,
+        timeout=DEFAULT_TIMEOUT,
     )
     print("EVENT", resp.status_code)
     if resp.status_code != 202:
@@ -134,7 +136,7 @@ def schedule_event(base_url, token):
         f"{base_url}/schedule",
         json=payload,
         headers={"Authorization": f"Bearer {token}"},
-        timeout=10,
+        timeout=DEFAULT_TIMEOUT,
     )
     print("SCHEDULE", resp.status_code)
     if resp.status_code != 201:


### PR DESCRIPTION
## Summary
- use `manylinux2014` wheels when packaging Azure Functions
- build deployment packages with Python 3.10
- increase HTTP timeout used by integration tests

## Testing
- `python -m py_compile infra/__main__.py scripts/test_azure_functions.py`

------
https://chatgpt.com/codex/tasks/task_e_68434ab3d8c0832e8bb4757cf82a8bc3