### PR TITLE
Add dashboard analytics and notifications

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -97,3 +97,52 @@ async def create_event(event: EventIn, token: str = Depends(_get_token)):
         raise HTTPException(status_code=resp.status_code, detail=resp.text)
     return {"status": "queued"}
 
+
+@app.get("/notifications", response_class=HTMLResponse)
+async def notifications_page(request: Request):
+    """Render notifications page."""
+    return templates.TemplateResponse("notifications.html", {"request": request})
+
+
+@app.get("/notifications.json")
+async def notifications(token: str = Depends(_get_token)):
+    """Return recent task notifications."""
+    headers = _api_headers(token)
+    resp = requests.get(f"{API_BASE}/tasks", headers=headers)
+    if resp.status_code >= 300:
+        raise HTTPException(status_code=resp.status_code, detail=resp.text)
+    tasks = resp.json()
+    tasks.sort(key=lambda t: t.get("updated_at", t.get("created_at", "")), reverse=True)
+    notifs = [
+        {
+            "id": t.get("id"),
+            "status": t.get("status"),
+            "updated_at": t.get("updated_at"),
+        }
+        for t in tasks[:20]
+    ]
+    return {"notifications": notifs}
+
+
+@app.get("/analytics.json")
+async def analytics(token: str = Depends(_get_token)):
+    """Return basic analytics derived from tasks."""
+    headers = _api_headers(token)
+    resp = requests.get(f"{API_BASE}/tasks", headers=headers)
+    if resp.status_code >= 300:
+        raise HTTPException(status_code=resp.status_code, detail=resp.text)
+    tasks = resp.json()
+    total = len(tasks)
+    status_counts: dict[str, int] = {}
+    total_cost = 0.0
+    for t in tasks:
+        status = t.get("status", "unknown")
+        status_counts[status] = status_counts.get(status, 0) + 1
+        cost = t.get("cost", {}).get("cost")
+        if cost is not None:
+            try:
+                total_cost += float(cost)
+            except Exception:
+                pass
+    return {"total": total, "status": status_counts, "cost": total_cost}
+

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -1,8 +1,46 @@
 <!DOCTYPE html>
 <html>
-<head><title>Dashboard</title></head>
+<head>
+    <title>Lightning Dashboard</title>
+    <script>
+        async function loadAnalytics() {
+            const resp = await fetch('/analytics.json');
+            if (resp.ok) {
+                const data = await resp.json();
+                document.getElementById('total-tasks').textContent = data.total;
+                document.getElementById('total-cost').textContent = '$' + data.cost.toFixed(4);
+                const status = data.status || {};
+                document.getElementById('pending-count').textContent = status.pending || 0;
+                document.getElementById('started-count').textContent = status.started || 0;
+                document.getElementById('error-count').textContent = status.error || 0;
+            }
+        }
+        async function loadFeed() {
+            const resp = await fetch('/notifications.json');
+            if (resp.ok) {
+                const data = await resp.json();
+                const list = document.getElementById('activity-feed');
+                list.innerHTML = '';
+                (data.notifications || []).forEach(n => {
+                    const li = document.createElement('li');
+                    li.textContent = `${n.id}: ${n.status}`;
+                    list.appendChild(li);
+                });
+            }
+        }
+        function refresh() { loadAnalytics(); loadFeed(); }
+        window.onload = function() { refresh(); setInterval(refresh, 5000); };
+    </script>
+</head>
 <body>
-<h1>Lightening Dashboard</h1>
-<p>Welcome to the dashboard.</p>
+    <h1>Lightning Dashboard</h1>
+    <div id="analytics">
+        <p>Total tasks: <span id="total-tasks">0</span></p>
+        <p>Pending: <span id="pending-count">0</span> | Started: <span id="started-count">0</span> | Error: <span id="error-count">0</span></p>
+        <p>Total cost: <span id="total-cost">$0.0000</span></p>
+    </div>
+    <h2>Activity Feed</h2>
+    <ul id="activity-feed"></ul>
+    <p><a href="/tasks">View Task Details</a></p>
 </body>
 </html>

--- a/dashboard/templates/notifications.html
+++ b/dashboard/templates/notifications.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Notifications</title>
+    <script>
+        async function loadNotifications() {
+            const resp = await fetch('/notifications.json');
+            if (!resp.ok) return;
+            const data = await resp.json();
+            const list = document.getElementById('notifications');
+            list.innerHTML = '';
+            (data.notifications || []).forEach(n => {
+                const li = document.createElement('li');
+                li.textContent = `${n.id}: ${n.status}`;
+                list.appendChild(li);
+            });
+        }
+        window.onload = function() { loadNotifications(); setInterval(loadNotifications, 5000); };
+    </script>
+</head>
+<body>
+    <h1>Notifications</h1>
+    <ul id="notifications"></ul>
+</body>
+</html>

--- a/dashboard/templates/tasks.html
+++ b/dashboard/templates/tasks.html
@@ -25,6 +25,21 @@
             document.getElementById('total-cost').textContent = '$' + total.toFixed(4);
         }
         let logInterval;
+        function parseHistory(text) {
+            const lines = text.split(/\r?\n/);
+            const history = [];
+            let current = null;
+            lines.forEach(line => {
+                if (line.startsWith('$ ')) {
+                    if (current) history.push(current);
+                    current = {cmd: line.slice(2), output: ''};
+                } else if (current) {
+                    current.output += line + '\n';
+                }
+            });
+            if (current) history.push(current);
+            return history;
+        }
         async function showLogs(id) {
             if (logInterval) {
                 clearInterval(logInterval);
@@ -33,7 +48,16 @@
                 const resp = await fetch('/tasks/' + id + '.json');
                 if (resp.status === 200) {
                     const data = await resp.json();
-                    document.getElementById('logs').textContent = data.logs || 'No logs';
+                    const logs = data.logs || '';
+                    document.getElementById('logs').textContent = logs || 'No logs';
+                    const history = parseHistory(logs);
+                    const container = document.getElementById('history');
+                    container.innerHTML = '';
+                    history.forEach(h => {
+                        const div = document.createElement('div');
+                        div.innerHTML = `<b>$ ${h.cmd}</b><pre>${h.output}</pre>`;
+                        container.appendChild(div);
+                    });
                 }
             }
             await fetchLogs();
@@ -51,5 +75,6 @@
     </table>
     <p>Total cost: <span id="total-cost">$0.0000</span></p>
     <pre id="logs" style="background:#f0f0f0;padding:1em;"></pre>
+    <div id="history"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend dashboard API with `/notifications` and `/analytics` data routes
- show activity feed and analytics on the index page
- display command history in task monitor
- add a notifications page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843dc912434832eb231d7e9cb873f2a