### PR TITLE
Enable email verification via Azure Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ pulumi config set domain agentsmith.in
 pulumi up
 ```
 
-Pulumi automatically:
-- Creates all Azure resources (Function App, Cosmos DB, Service Bus, etc.)
+ Pulumi automatically:
+ - Creates all Azure resources (Function App, Cosmos DB, Service Bus, Communication Service, Email Service, etc.)
 - Packages the Azure Functions code
 - Deploys the function code to the Function App
 - Grants the Function App's managed identity read access to the deployment
@@ -233,6 +233,10 @@ messaging:
 - `REPO_CONTAINER` &mdash; container storing repository URLs. Defaults to `repos`.
 - `SCHEDULE_CONTAINER` &mdash; container used by the scheduler. Defaults to `schedules`.
 - `TASK_CONTAINER` &mdash; container storing worker task records. Defaults to `tasks`.
+- `ACS_CONNECTION` &mdash; connection string for Azure Communication Services email.
+- This connection string is retrieved from the Communication Service, while an additional Email Service resource handles domains.
+- `ACS_SENDER` &mdash; default sender email address for verification messages. Defaults to `no-reply@<domain>` where `<domain>` comes from the Pulumi `domain` config (set in the GitHub workflow).
+- `VERIFY_BASE_URL` &mdash; base URL used to generate verification links.
 - `APPINSIGHTS_INSTRUMENTATIONKEY` &mdash; instrumentation key for Application Insights. Pulumi sets this automatically.
 - `WEBSITE_RUN_FROM_PACKAGE` &mdash; URL of the function package. Pulumi grants
   the Function App's managed identity read access so the app can download the

--- a/azure-function/UserAuth/function.json
+++ b/azure-function/UserAuth/function.json
@@ -5,7 +5,7 @@
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "methods": ["post"],
+      "methods": ["post", "get"],
       "route": "auth/{action}"
     },
     {

--- a/azure-function/requirements.txt
+++ b/azure-function/requirements.txt
@@ -8,3 +8,4 @@ azure-identity
 azure-mgmt-containerinstance
 pyjwt
 cryptography==41.0.7
+azure-communication-email

--- a/chat_client/auth_app.py
+++ b/chat_client/auth_app.py
@@ -251,7 +251,7 @@ async def register(
     username: str = Form(...),
     password: str = Form(...),
     confirm_password: str = Form(...),
-    email: str = Form(default=""),
+    email: str = Form(...),
     csrf_token: str = Form(default="")
 ):
     """Handle user registration."""
@@ -266,9 +266,12 @@ async def register(
     
     if password != confirm_password:
         return RedirectResponse(url="/register?error=password_mismatch", status_code=302)
-    
+
     if not _is_strong_password(password):
         return RedirectResponse(url="/register?error=password_too_short", status_code=302)
+
+    if not email:
+        return RedirectResponse(url="/register?error=email_required", status_code=302)
     
     try:
         # Call Azure Function auth endpoint

--- a/chat_client/templates/register.html
+++ b/chat_client/templates/register.html
@@ -167,9 +167,9 @@
             </div>
             
             <div class="form-group">
-                <label for="email">Email (Optional)</label>
-                <input type="email" id="email" name="email" placeholder="your.email@example.com">
-                <div class="password-requirements">For approval notifications</div>
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" required placeholder="your.email@example.com">
+                <div class="password-requirements">Used for verification and notifications</div>
             </div>
             
             <div class="form-group">


### PR DESCRIPTION
## Summary
- set up Azure Communication Service in Pulumi infrastructure
- send verification emails on registration and add verify endpoint
- require email during registration and update templates
- expose email env vars in README
- adjust tests for new functionality
- create dedicated Email Service resource for domains
- set default email sender based on domain

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843e5815ed4832ea991b695b61cd012