### PR TITLE
Fix login cookie for http

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,10 @@ Function. Configure `AUTH_TOKEN` with your JWT and set `NOTIFY_URL` for the
 Azure Functions as `http://<chainlit_host>/notify` so `UserMessenger` can
 forward messages back to the client.
 
+If your authentication gateway runs on a different host, set
+`AUTH_GATEWAY_URL` accordingly. When unset, the URL is inferred from the
+request's forwarded headers.
+
 ## Dashboard
 
 A simple FastAPI dashboard is located in the `dashboard/` directory. It allows

--- a/tests/test_chainlit_app.py
+++ b/tests/test_chainlit_app.py
@@ -202,3 +202,15 @@ def test_notify_correct_user(monkeypatch):
         asyncio.run(module.notify(req, {'user_id': 'missing', 'message': 'hi'}))
 
 
+def test_resolve_gateway_fallback(monkeypatch):
+    monkeypatch.delenv('AUTH_GATEWAY_URL', raising=False)
+    capture = {}
+    _, module = load_chainlit_app(monkeypatch, capture)
+
+    request = types.SimpleNamespace(
+        headers={'x-forwarded-proto': 'https', 'x-forwarded-host': 'agentsmith.in'},
+        url=types.SimpleNamespace(scheme='https', hostname='agentsmith.in')
+    )
+    assert module._resolve_gateway_url(request) == 'https://agentsmith.in'
+
+


### PR DESCRIPTION
## Summary
- ensure cookies are set even on HTTP
- infer gateway host when not configured

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844423bef30832e8de7473ffa34d038