### PR TITLE
Expose services through single port

### DIFF
--- a/AUTH_SYSTEM_GUIDE.md
+++ b/AUTH_SYSTEM_GUIDE.md
@@ -6,9 +6,8 @@ The Lightning Chat UI container has been enhanced with a comprehensive authentic
 
 ## Architecture
 
-### Multi-Service Design
-- **Auth Gateway** (Port 8000): FastAPI-based authentication service
-- **Chat Service** (Port 8001): Chainlit-based chat interface with auth middleware
+-### Multi-Service Design
+- **Gateway** (Port 443): Routes `/auth` to the auth service and `/chat` to the chat interface
 - **Azure Functions**: Backend API for user management and authentication
 
 ### Authorization Flow
@@ -27,7 +26,7 @@ The Lightning Chat UI container has been enhanced with a comprehensive authentic
 - **Database Schema**: Added status, role, email, timestamps
 
 ### 2. Authentication Gateway (`/chat_client/auth_app.py`)
-- **FastAPI Service**: Runs on port 8000
+- **FastAPI Service**: Mounted under `/auth`
 - **JWT Verification**: Secure token handling
 - **Session Management**: HTTP-only cookies
 - **Admin Panel**: User management interface
@@ -61,7 +60,7 @@ export JWT_SIGNING_KEY="your-jwt-signing-key"
 
 # Required for Chat Client
 export AUTH_API_URL="https://your-function-app.azurewebsites.net/api"
-export CHAINLIT_URL="http://localhost:8001"  # In Docker: http://chainlit:8001
+export CHAINLIT_URL="https://localhost/chat"  # In Docker: https://gateway/chat
 ```
 
 ### 2. Deploy Azure Functions
@@ -81,7 +80,7 @@ chmod +x start.sh
 
 # Docker deployment
 docker build -t lightning-chat .
-docker run -p 8000:8000 -p 8001:8001 \
+docker run -p 443:443 \
   -e AUTH_API_URL="https://your-function-app.azurewebsites.net/api" \
   -e JWT_SIGNING_KEY="your-jwt-signing-key" \
   lightning-chat
@@ -109,9 +108,9 @@ python test_auth_flow.py
 ```
 
 ### Manual Testing Steps
-1. **Registration**: Visit http://localhost:8000/register
+1. **Registration**: Visit https://localhost/auth/register
 2. **Waitlist Check**: Try logging in (should be blocked)
-3. **Admin Login**: Use admin credentials at http://localhost:8000/admin
+3. **Admin Login**: Use admin credentials at https://localhost/auth/admin
 4. **User Approval**: Approve pending users in admin panel
 5. **User Access**: Approved users can now access chat
 
@@ -272,8 +271,8 @@ python test_auth_flow.py
 
 ```bash
 # Check service health
-curl http://localhost:8000/health
-curl http://localhost:8001/health
+curl https://localhost/auth/health
+curl https://localhost/chat/health
 
 # Test Azure Function
 curl -X POST "https://your-function-app.azurewebsites.net/api/register" \

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Functions Core Tools) or through a `.env` file in the repository root.
     "OPENAI_MODEL": "gpt-3.5-turbo",
     "SERVICEBUS_CONNECTION": "<namespace-connection-string>",
     "SERVICEBUS_QUEUE": "chat-events",
-    "NOTIFY_URL": "http://localhost:8000/notify",
+    "NOTIFY_URL": "https://localhost/chat/notify",
     "JWT_SIGNING_KEY": "secret",
     "COSMOS_CONNECTION": "<cosmos-connection-string>",
     "COSMOS_DATABASE": "lightning",
@@ -282,7 +282,7 @@ OPENAI_API_KEY=sk-...
 OPENAI_MODEL=gpt-3.5-turbo
 SERVICEBUS_CONNECTION=<namespace-connection-string>
 SERVICEBUS_QUEUE=chat-events
-NOTIFY_URL=http://localhost:8000/notify
+NOTIFY_URL=https://localhost/chat/notify
 JWT_SIGNING_KEY=secret
 COSMOS_CONNECTION=<cosmos-connection-string>
 COSMOS_DATABASE=lightning

--- a/auth_flow_demo.py
+++ b/auth_flow_demo.py
@@ -11,8 +11,8 @@ import os
 from datetime import datetime
 
 # Configuration
-AUTH_SERVICE_URL = "http://localhost:8000"
-CHAT_SERVICE_URL = "http://localhost:8001"
+AUTH_SERVICE_URL = "https://localhost/auth"
+CHAT_SERVICE_URL = "https://localhost/chat"
 AUTH_API_URL = os.environ.get("AUTH_API_URL", "https://your-function-app.azurewebsites.net/api")
 
 class Colors:

--- a/chat_client/Dockerfile
+++ b/chat_client/Dockerfile
@@ -7,6 +7,7 @@ COPY chat_client/chainlit_app.py ./chainlit_app.py
 COPY chat_client/auth_app.py ./auth_app.py
 COPY chat_client/templates/ ./templates/
 COPY chat_client/start.sh ./start.sh
+COPY chat_client/gateway_app.py ./gateway_app.py
 COPY events/ ./events/
 COPY dashboard/ ./dashboard/
 COPY common/ ./common/
@@ -26,8 +27,8 @@ RUN pip install --no-cache-dir \
 # Make startup script executable
 RUN chmod +x ./start.sh
 
-# Expose ports for both services
-EXPOSE 8000 8001
+# Expose HTTPS port for the gateway
+EXPOSE 443
 
 # Run the multi-service startup script
 CMD ["./start.sh"]

--- a/chat_client/README.md
+++ b/chat_client/README.md
@@ -4,18 +4,13 @@ This directory contains the enhanced Lightning Chat client with authentication.
 
 ## Architecture
 
-The chat client now consists of two services:
+The chat client exposes a single gateway service:
 
-1. **Authentication Gateway** (Port 8000)
-   - User registration and login
-   - Session management
-   - JWT token verification
-   - Redirects authenticated users to chat
-
-2. **Chainlit Chat App** (Port 8001)  
-   - AI chat interface
-   - Protected by authentication middleware
-   - Event logging and user context
+1. **Gateway on Port 443**
+   - Routes `/auth` to the authentication endpoints
+   - Routes `/chat` to the Chainlit interface
+   - Handles user sessions and JWT verification
+   - Provides a single HTTPS endpoint for the UI
 
 ## Features
 
@@ -48,7 +43,7 @@ JWT_SIGNING_KEY=your-secret-signing-key
 Optional:
 ```bash
 SESSION_SECRET=your-session-secret
-CHAINLIT_URL=http://localhost:8001  # For custom chat service URL
+CHAINLIT_URL=https://localhost/chat  # For custom gateway URL
 EVENT_API_URL=https://your-function-app.azurewebsites.net/api/events
 AUTH_TOKEN=your-api-auth-token
 ```
@@ -77,7 +72,7 @@ python ../test_local_auth.py
 ```
 
 ### Manual Testing
-1. Visit http://localhost:8000
+1. Visit https://localhost/auth
 2. Register a new account
 3. Login with credentials
 4. Access chat interface
@@ -92,7 +87,7 @@ docker build -t lightning-chat .
 
 ### Run
 ```bash
-docker run -p 8000:8000 -p 8001:8001 \
+docker run -p 443:443 \
   -e AUTH_API_URL="https://your-function-app.azurewebsites.net/api/auth" \
   -e JWT_SIGNING_KEY="your-secret-key" \
   lightning-chat
@@ -114,20 +109,20 @@ chat_client/
 
 ## API Endpoints
 
-### Authentication Gateway (Port 8000)
-- `GET /` - Login page (redirects if authenticated)
-- `POST /login` - User authentication
-- `GET /register` - Registration page  
-- `POST /register` - User registration
-- `GET /chat` - Redirect to chat (requires auth)
-- `GET /logout` - User logout
-- `GET /health` - Health check
+### Authentication Gateway (`/auth`)
+- `GET /auth/` - Login page (redirects if authenticated)
+- `POST /auth/login` - User authentication
+- `GET /auth/register` - Registration page
+- `POST /auth/register` - User registration
+- `GET /auth/chat` - Redirect to chat (requires auth)
+- `GET /auth/logout` - User logout
+- `GET /auth/health` - Health check
 
-### Chat Service (Port 8001)
-- `GET /` - Chainlit chat interface (requires auth)
-- `POST /notify` - External message notifications
-- `GET /health` - Health check
-- `GET /dashboard` - Analytics dashboard
+### Chat Service (`/chat`)
+- `GET /chat/` - Chainlit chat interface (requires auth)
+- `POST /chat/notify` - External message notifications
+- `GET /chat/health` - Health check
+- `GET /chat/dashboard` - Analytics dashboard
 
 ## Security Features
 
@@ -154,7 +149,7 @@ Make sure your Azure Function has the UserAuth function deployed and configured.
 
 1. **Services won't start**
    - Check environment variables are set
-   - Verify ports 8000 and 8001 are available
+   - Verify port 443 is available
    - Check Python dependencies are installed
 
 2. **Authentication fails**
@@ -164,7 +159,7 @@ Make sure your Azure Function has the UserAuth function deployed and configured.
 
 3. **Chat not accessible**
    - Confirm authentication is working
-   - Check Chainlit service is running on port 8001
+   - Check the gateway service is running on port 443
    - Verify authentication middleware is working
 
 ### Logs

--- a/chat_client/auth_app.py
+++ b/chat_client/auth_app.py
@@ -25,7 +25,6 @@ import uvicorn
 AUTH_API_URL = os.environ.get("AUTH_API_URL", "")  # Azure Function auth endpoint
 JWT_SIGNING_KEY = os.environ.get("JWT_SIGNING_KEY", "")
 SESSION_SECRET = os.environ.get("SESSION_SECRET", "your-secret-key-change-in-production")
-CHAINLIT_PORT = os.environ.get("CHAINLIT_PORT", "8001")
 
 # Setup
 app = FastAPI(title="Lightning Chat Authentication")
@@ -102,7 +101,7 @@ def verify_token(token: str) -> Optional[str]:
 
 
 def _resolve_chainlit_url(request: Request) -> str:
-    """Return the URL of the Chainlit service based on the request."""
+    """Return the base URL for the Chainlit service."""
     configured = os.environ.get("CHAINLIT_URL")
     if configured:
         return configured
@@ -110,7 +109,7 @@ def _resolve_chainlit_url(request: Request) -> str:
     scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
     host = request.headers.get("x-forwarded-host", request.url.hostname or "localhost")
     host = host.split(":")[0]
-    return f"{scheme}://{host}:{CHAINLIT_PORT}"
+    return f"{scheme}://{host}/chat"
 
 
 async def get_current_user(request: Request) -> Optional[str]:
@@ -521,4 +520,4 @@ async def health_check():
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=443)

--- a/chat_client/gateway_app.py
+++ b/chat_client/gateway_app.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+from starlette.responses import RedirectResponse
+
+from auth_app import app as auth_app
+from chainlit_app import fastapi_app as chat_app
+
+app = FastAPI(title="Lightning Chat Gateway")
+
+# Mount the auth and chat applications under separate routes
+app.mount("/auth", auth_app)
+app.mount("/chat", chat_app)
+
+@app.get("/", include_in_schema=False)
+async def root():
+    """Redirect to the authentication gateway."""
+    return RedirectResponse(url="/auth")
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/chat_client/start.sh
+++ b/chat_client/start.sh
@@ -1,84 +1,20 @@
 #!/bin/bash
 
-# Lightning Chat - Multi-Service Startup Script
-# This script starts both the authentication gateway and Chainlit chat app
-
 set -e
 
-echo "⚡ Lightning Chat - Starting Services"
-echo "=" | sed 's/./=/g' | head -c 50 && echo
+echo "⚡ Lightning Chat - Starting Gateway"
 
-# Check required environment variables
+# Verify required environment variables
 check_env_var() {
     if [ -z "${!1}" ]; then
         echo "❌ Missing required environment variable: $1"
-        return 1
+        exit 1
     fi
 }
 
-echo "🔍 Checking environment variables..."
-if ! check_env_var "AUTH_API_URL" || ! check_env_var "JWT_SIGNING_KEY"; then
-    echo
-    echo "Required environment variables:"
-    echo "- AUTH_API_URL: URL of the Azure Function auth endpoint"
-    echo "- JWT_SIGNING_KEY: Secret key for JWT token verification"
-    echo "- SESSION_SECRET: Secret for session management (optional)"
-    exit 1
-fi
+check_env_var "AUTH_API_URL"
+check_env_var "JWT_SIGNING_KEY"
 
-echo "✅ Environment variables OK"
+# Run the gateway on HTTPS port 443
+exec python -m uvicorn gateway_app:app --host 0.0.0.0 --port 443
 
-# Function to cleanup background processes
-cleanup() {
-    echo
-    echo "🛑 Shutting down Lightning Chat services..."
-    jobs -p | xargs -r kill
-    wait
-    echo "👋 Lightning Chat services stopped"
-    exit 0
-}
-
-# Set up signal handlers
-trap cleanup SIGINT SIGTERM
-
-# Start authentication gateway in background
-echo "🔐 Starting Authentication Gateway on port 8000..."
-python -m uvicorn auth_app:app --host 0.0.0.0 --port 8000 &
-AUTH_PID=$!
-
-# Wait a moment for auth gateway to start
-sleep 3
-
-# Check if auth gateway started successfully
-if ! kill -0 $AUTH_PID 2>/dev/null; then
-    echo "❌ Authentication gateway failed to start"
-    exit 1
-fi
-
-echo "✅ Authentication gateway started (PID: $AUTH_PID)"
-
-# Start Chainlit app in background
-echo "💬 Starting Chainlit Chat App on port 8001..."
-chainlit run chainlit_app.py --host 0.0.0.0 --port 8001 &
-CHAINLIT_PID=$!
-
-# Wait a moment for Chainlit to start
-sleep 3
-
-# Check if Chainlit started successfully
-if ! kill -0 $CHAINLIT_PID 2>/dev/null; then
-    echo "❌ Chainlit app failed to start"
-    kill $AUTH_PID 2>/dev/null || true
-    exit 1
-fi
-
-echo "✅ Chainlit chat app started (PID: $CHAINLIT_PID)"
-echo
-echo "🚀 Lightning Chat is ready!"
-echo "📱 Access the application at: http://localhost:8000"
-echo "🔐 Users must authenticate before accessing chat"
-echo
-echo "Press Ctrl+C to stop all services"
-
-# Wait for both processes
-wait

--- a/chat_client/start_services.py
+++ b/chat_client/start_services.py
@@ -12,34 +12,18 @@ import subprocess
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
-def start_auth_gateway():
-    """Start the authentication gateway on port 8000."""
-    print("🔐 Starting Authentication Gateway on port 8000...")
+def start_gateway():
+    """Run the combined gateway on port 443."""
+    print("🚀 Starting Gateway on port 443...")
     try:
         subprocess.run([
-            sys.executable, "-m", "uvicorn", 
-            "auth_app:app", 
-            "--host", "0.0.0.0", 
-            "--port", "8000",
-            "--reload"
+            sys.executable, "-m", "uvicorn",
+            "gateway_app:app",
+            "--host", "0.0.0.0",
+            "--port", "443"
         ], check=True)
     except subprocess.CalledProcessError as e:
-        print(f"❌ Auth gateway failed to start: {e}")
-        sys.exit(1)
-
-def start_chainlit_app():
-    """Start the Chainlit chat app on port 8001."""
-    print("💬 Starting Chainlit Chat App on port 8001...")
-    # Give auth gateway time to start
-    time.sleep(2)
-    try:
-        subprocess.run([
-            "chainlit", "run", "chainlit_app.py", 
-            "--host", "0.0.0.0", 
-            "--port", "8001"
-        ], check=True)
-    except subprocess.CalledProcessError as e:
-        print(f"❌ Chainlit app failed to start: {e}")
+        print(f"❌ Gateway failed to start: {e}")
         sys.exit(1)
 
 def signal_handler(signum, frame):
@@ -67,21 +51,12 @@ def main():
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
     
-    # Start both services concurrently
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        auth_future = executor.submit(start_auth_gateway)
-        chat_future = executor.submit(start_chainlit_app)
-        
-        try:
-            # Wait for both services
-            auth_future.result()
-            chat_future.result()
-        except KeyboardInterrupt:
-            print("\n🛑 Received shutdown signal")
-        except Exception as e:
-            print(f"❌ Service error: {e}")
-        finally:
-            print("👋 Lightning Chat services stopped")
+    try:
+        start_gateway()
+    except KeyboardInterrupt:
+        print("\n🛑 Received shutdown signal")
+    finally:
+        print("👋 Lightning Chat services stopped")
 
 if __name__ == "__main__":
     main()

--- a/create_admin_user.py
+++ b/create_admin_user.py
@@ -135,7 +135,7 @@ def create_admin_user():
         if user.get('role') == 'admin' and user.get('status') == 'approved':
             log_success("Admin user is ready to use!")
             print(f"\n{Colors.GREEN}You can now login to the admin panel at:{Colors.END}")
-            print(f"{Colors.GREEN}http://localhost:8000/admin{Colors.END}")
+            print(f"{Colors.GREEN}https://localhost/auth/admin{Colors.END}")
         else:
             log_error("Admin user setup incomplete")
             

--- a/deployment_test_guide.py
+++ b/deployment_test_guide.py
@@ -26,17 +26,17 @@ def test_endpoints():
         {
             "name": "Authentication Flow",
             "description": "Test user registration and login",
-            "example": "1. Visit http://<ui-url>:8000/\n   2. Register new account\n   3. Login with credentials"
+            "example": "1. Visit https://<ui-url>/auth\n   2. Register new account\n   3. Login with credentials"
         },
         {
             "name": "Chat Interface", 
             "description": "Authenticated Chainlit chat UI",
-            "example": "After login, access chat at http://<ui-url>:8000/chat"
+            "example": "After login, access chat at https://<ui-url>/chat"
         },
         {
             "name": "Health Checks",
             "description": "Service health monitoring",
-            "example": "GET http://<ui-url>:8000/health (Auth Gateway)\n   GET http://<ui-url>:8001/health (Chat Service)"
+            "example": "GET https://<ui-url>/auth/health (Auth Gateway)\n   GET https://<ui-url>/chat/health (Chat Service)"
         },
         {
             "name": "Event API",
@@ -74,7 +74,7 @@ def get_azure_resources():
     print("1. Go to https://portal.azure.com")
     print("2. Navigate to Resource Group 'lightning'")
     print("3. Look for:")
-    print("   - Container Instance 'chat-ui' → Get public IP (Auth Gateway on :8000, Chat on :8001)")
+    print("   - Container Instance 'chat-ui' → Get public IP (Gateway on :443)")
     print("   - Function App 'lightning-func-*' → Get URL (API endpoints)")
     print("   - Container Registry 'lightningacr' → Container images")
     print("   - Cosmos DB 'lightning-cosmos-*' → User and event storage")

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -340,8 +340,7 @@ ui_container = containerinstance.ContainerGroup(
                 name="chat-ui",
                 image=ui_image,
                 ports=[
-                    containerinstance.ContainerPortArgs(port=8000),
-                    containerinstance.ContainerPortArgs(port=8001),
+                containerinstance.ContainerPortArgs(port=443),
                 ],
                 environment_variables=[
                     containerinstance.EnvironmentVariableArgs(
@@ -393,8 +392,7 @@ ui_container = containerinstance.ContainerGroup(
         ],
         ip_address=containerinstance.IpAddressArgs(
             ports=[
-                containerinstance.PortArgs(protocol="TCP", port=8000),
-                containerinstance.PortArgs(protocol="TCP", port=8001),
+                containerinstance.PortArgs(protocol="TCP", port=443),
             ],
             type=containerinstance.ContainerGroupIpAddressType.PUBLIC,
         ),
@@ -601,7 +599,7 @@ gitea_container = containerinstance.ContainerGroup(
 )
 
 # Wire the functions back to the Chainlit UI once the container address is known
-notify_url = ui_container.ip_address.apply(lambda ip: f"http://{ip.fqdn}/notify")
+notify_url = ui_container.ip_address.apply(lambda ip: f"https://{ip.fqdn}/chat/notify")
 
 # Function to create and upload Function App package
 def create_function_package():

--- a/test_local_auth.py
+++ b/test_local_auth.py
@@ -97,8 +97,7 @@ def start_local_services():
     os.chdir(Path(__file__).parent / "chat_client")
     
     print("🚀 Starting Lightning Chat services locally...")
-    print("📍 Auth Gateway: http://localhost:8000")
-    print("💬 Chat Service: http://localhost:8001")
+    print("📍 Gateway: https://localhost")
     print("\nPress Ctrl+C to stop services")
     
     try:
@@ -134,7 +133,7 @@ def main():
     
     print("\n" + "=" * 50)
     print("🎯 Test Checklist:")
-    print("1. Visit http://localhost:8000")
+    print("1. Visit https://localhost/auth")
     print("2. Try to access chat without logging in (should redirect)")
     print("3. Register a new account")
     print("4. Login with your credentials") 


### PR DESCRIPTION
## Summary
- route the chat and auth services under a gateway
- expose only HTTPS port 443
- update docs and tests for the new gateway

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684468a788bc832eb025bb1b1d8b96b7