### PR TITLE
Create repo during registration

### DIFF
--- a/azure-function/RegisterRepo/__init__.py
+++ b/azure-function/RegisterRepo/__init__.py
@@ -1,6 +1,8 @@
-import json
 import os
 import logging
+from typing import Optional
+
+import requests
 
 import azure.functions as func
 from azure.cosmos import CosmosClient, PartitionKey
@@ -9,6 +11,8 @@ from auth import verify_token
 COSMOS_CONN = os.environ.get("COSMOS_CONNECTION")
 COSMOS_DB = os.environ.get("COSMOS_DATABASE", "lightning")
 REPO_CONTAINER = os.environ.get("REPO_CONTAINER", "repos")
+GITEA_URL = os.environ.get("GITEA_URL")
+GITEA_TOKEN = os.environ.get("GITEA_TOKEN")
 
 _client = CosmosClient.from_connection_string(COSMOS_CONN)
 _db = _client.create_database_if_not_exists(COSMOS_DB)
@@ -17,22 +21,43 @@ _container = _db.create_container_if_not_exists(
 )
 
 
+def _create_repo(user: str) -> Optional[str]:
+    """Create a new Gitea repository and return its clone URL."""
+    if not (GITEA_URL and GITEA_TOKEN):
+        logging.warning("Gitea not configured")
+        return None
+    data = {"name": user, "private": False, "auto_init": True}
+    headers = {"Authorization": f"token {GITEA_TOKEN}"}
+    try:
+        r = requests.post(f"{GITEA_URL}/api/v1/user/repos", json=data, headers=headers, timeout=10)
+    except Exception as e:
+        logging.error("Gitea request failed: %s", e)
+        return None
+    if r.status_code not in (200, 201):
+        logging.error("Gitea repo creation failed: %s %s", r.status_code, r.text)
+        return None
+    try:
+        return r.json().get("clone_url")
+    except Exception:
+        return None
+
+
 def main(req: func.HttpRequest) -> func.HttpResponse:
     try:
-        data = req.get_json()
+        req.get_json()
     except ValueError:
-        return func.HttpResponse("Invalid JSON", status_code=400)
+        pass
 
     try:
         user_id = verify_token(req.headers.get("Authorization"))
     except Exception:
         return func.HttpResponse("Unauthorized", status_code=401)
 
-    repo = data.get("repo")
-    if not repo:
-        return func.HttpResponse("Missing repo", status_code=400)
+    clone_url = _create_repo(user_id)
+    if clone_url is None:
+        return func.HttpResponse("Failed", status_code=500)
 
-    entity = {"id": "repo", "pk": user_id, "repo": repo}
+    entity = {"id": "repo", "pk": user_id, "repo": clone_url}
     try:
         _container.upsert_item(entity)
     except Exception as e:

--- a/tests/test_register_repo.py
+++ b/tests/test_register_repo.py
@@ -1,0 +1,91 @@
+import os
+import sys
+import types
+import importlib.util
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def load_register_repo(monkeypatch, capture, status=201):
+    azure_mod = types.ModuleType('azure')
+    cosmos_mod = types.ModuleType('cosmos')
+
+    class DummyContainer:
+        def upsert_item(self, entity):
+            capture['entity'] = entity
+
+    class DummyDatabase:
+        def create_container_if_not_exists(self, *a, **k):
+            return DummyContainer()
+
+    class DummyClient:
+        def create_database_if_not_exists(self, *a, **k):
+            return DummyDatabase()
+
+    cosmos_mod.CosmosClient = types.SimpleNamespace(from_connection_string=lambda *a, **k: DummyClient())
+    cosmos_mod.PartitionKey = lambda path: {'path': path}
+    azure_mod.cosmos = cosmos_mod
+
+    func_mod = types.ModuleType('functions')
+    class DummyRequest:
+        def __init__(self, headers=None):
+            self.headers = headers or {}
+        def get_json(self):
+            return {}
+    class DummyResponse:
+        def __init__(self, body='', status_code=200):
+            self.body = body
+            self.status_code = status_code
+    func_mod.HttpRequest = DummyRequest
+    func_mod.HttpResponse = DummyResponse
+    azure_mod.functions = func_mod
+
+    auth_mod = types.ModuleType('auth')
+    def verify_token(h):
+        if h == 'Bearer good':
+            return 'user1'
+        raise Exception('bad')
+    auth_mod.verify_token = verify_token
+
+    req_mod = types.ModuleType('requests')
+    def post(url, json=None, headers=None, timeout=None):
+        capture['post'] = (url, json, headers)
+        return types.SimpleNamespace(status_code=status, text='', json=lambda: {'clone_url': 'http://gitea/repo.git'})
+    req_mod.post = post
+
+    monkeypatch.setitem(sys.modules, 'azure', azure_mod)
+    monkeypatch.setitem(sys.modules, 'azure.cosmos', cosmos_mod)
+    monkeypatch.setitem(sys.modules, 'azure.functions', func_mod)
+    monkeypatch.setitem(sys.modules, 'auth', auth_mod)
+    monkeypatch.setitem(sys.modules, 'requests', req_mod)
+
+    spec = importlib.util.spec_from_file_location('RegisterRepo', os.path.join(os.path.dirname(__file__), '..', 'azure-function', 'RegisterRepo', '__init__.py'))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['RegisterRepo'] = module
+    spec.loader.exec_module(module)
+    return module, DummyRequest
+
+
+def test_repo_created(monkeypatch):
+    os.environ['COSMOS_CONNECTION'] = 'c'
+    os.environ['GITEA_URL'] = 'http://gitea'
+    os.environ['GITEA_TOKEN'] = 'tok'
+    capture = {}
+    module, Req = load_register_repo(monkeypatch, capture)
+    req = Req(headers={'Authorization': 'Bearer good'})
+    resp = module.main(req)
+    assert resp.status_code == 200
+    assert capture['entity']['pk'] == 'user1'
+    assert capture['post'][0] == 'http://gitea/api/v1/user/repos'
+    assert capture['post'][2]['Authorization'] == 'token tok'
+
+
+def test_repo_failure(monkeypatch):
+    os.environ['COSMOS_CONNECTION'] = 'c'
+    os.environ['GITEA_URL'] = 'http://gitea'
+    os.environ['GITEA_TOKEN'] = 'tok'
+    capture = {}
+    module, Req = load_register_repo(monkeypatch, capture, status=500)
+    req = Req(headers={'Authorization': 'Bearer good'})
+    resp = module.main(req)
+    assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- automatically create a Gitea repository for each new user
- save the clone URL in Cosmos DB
- add tests for the new RegisterRepo behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684472f74bd0832eb188555c95155947