### PR TITLE
Handle cleanup for WorkerTaskRunner

### DIFF
--- a/azure-function/WorkerTaskRunner/__init__.py
+++ b/azure-function/WorkerTaskRunner/__init__.py
@@ -153,3 +153,10 @@ def main(msg: func.ServiceBusMessage) -> None:
         sender = _sb_client.get_queue_sender(queue_name=SERVICEBUS_QUEUE)
         with sender:
             sender.send_messages(message)
+        if _aci_client and task_entity.get("container_group"):
+            try:
+                _aci_client.container_groups.begin_delete(
+                    ACI_RESOURCE_GROUP, task_entity["container_group"]
+                )
+            except Exception as e:
+                logging.error("Failed to delete container group: %s", e)

--- a/tests/test_worker_main.py
+++ b/tests/test_worker_main.py
@@ -74,3 +74,186 @@ def test_worker_main_runs_agent(monkeypatch, capsys):
     assert info["tokens"] == 100
     assert info["event_count"] == 1
     assert info["runtime_sec"] >= 0
+
+
+def load_worker_task_runner(monkeypatch, capture):
+    azure_mod = types.ModuleType("azure")
+
+    cosmos_mod = types.ModuleType("cosmos")
+
+    class DummyContainer:
+        def create_container_if_not_exists(self, *a, **k):
+            return self
+
+        def create_database_if_not_exists(self, *a, **k):
+            return self
+
+        def upsert_item(self, item):
+            capture.setdefault("upserts", []).append(item)
+
+        def read_item(self, item, partition_key=None):
+            return {"repo": "r"}
+
+    cosmos_mod.CosmosClient = types.SimpleNamespace(
+        from_connection_string=lambda *a, **k: DummyContainer()
+    )
+    cosmos_mod.PartitionKey = lambda path: {"path": path}
+    azure_mod.cosmos = cosmos_mod
+
+    sb_mod = types.ModuleType("servicebus")
+
+    class DummySender:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def send_messages(self, msg):
+            capture["sent"] = json.loads(msg.body)
+
+    class DummySBClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def get_queue_sender(self, queue_name=None):
+            return DummySender()
+
+    sb_mod.ServiceBusClient = types.SimpleNamespace(
+        from_connection_string=lambda *a, **k: DummySBClient()
+    )
+
+    class DummyMessage:
+        def __init__(self, body):
+            self.body = body
+            self.application_properties = {}
+
+    sb_mod.ServiceBusMessage = DummyMessage
+    azure_mod.servicebus = sb_mod
+
+    func_mod = types.ModuleType("functions")
+
+    class SBMessage:
+        def __init__(self, body):
+            self._body = body.encode("utf-8")
+
+        def get_body(self):
+            return self._body
+
+    func_mod.ServiceBusMessage = SBMessage
+    azure_mod.functions = func_mod
+
+    identity_mod = types.ModuleType("identity")
+    identity_mod.DefaultAzureCredential = lambda: None
+    azure_mod.identity = identity_mod
+
+    aci_mod = types.ModuleType("containerinstance")
+
+    class DummyGroups:
+        def begin_create_or_update(self, rg, name, group):
+            capture["created"] = name
+            return types.SimpleNamespace(result=lambda: None)
+
+        def begin_delete(self, rg, name):
+            capture["deleted"] = name
+
+    class DummyACIClient:
+        def __init__(self, credential, sub_id):
+            self.container_groups = DummyGroups()
+
+    aci_mod.ContainerInstanceManagementClient = DummyACIClient
+
+    models_mod = types.ModuleType("containerinstance.models")
+
+    class Container:
+        def __init__(self, *a, **k):
+            pass
+
+    class ContainerGroup:
+        def __init__(self, *a, **k):
+            pass
+
+    class ContainerGroupRestartPolicy:
+        NEVER = "never"
+
+    class EnvironmentVariable:
+        def __init__(self, name=None, value=None):
+            self.name = name
+            self.value = value
+
+    class OperatingSystemTypes:
+        LINUX = "linux"
+
+    class ResourceRequests:
+        def __init__(self, cpu=None, memory_in_gb=None):
+            pass
+
+    class ResourceRequirements:
+        def __init__(self, requests=None):
+            pass
+
+    models_mod.Container = Container
+    models_mod.ContainerGroup = ContainerGroup
+    models_mod.ContainerGroupRestartPolicy = ContainerGroupRestartPolicy
+    models_mod.EnvironmentVariable = EnvironmentVariable
+    models_mod.OperatingSystemTypes = OperatingSystemTypes
+    models_mod.ResourceRequests = ResourceRequests
+    models_mod.ResourceRequirements = ResourceRequirements
+
+    azure_mod.mgmt = types.ModuleType("mgmt")
+    azure_mod.mgmt.containerinstance = aci_mod
+    aci_mod.models = models_mod
+
+    monkeypatch.setitem(sys.modules, "azure", azure_mod)
+    monkeypatch.setitem(sys.modules, "azure.cosmos", cosmos_mod)
+    monkeypatch.setitem(sys.modules, "azure.servicebus", sb_mod)
+    monkeypatch.setitem(sys.modules, "azure.functions", func_mod)
+    monkeypatch.setitem(sys.modules, "azure.identity", identity_mod)
+    monkeypatch.setitem(sys.modules, "azure.mgmt.containerinstance", aci_mod)
+    monkeypatch.setitem(
+        sys.modules, "azure.mgmt.containerinstance.models", models_mod
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "WorkerTaskRunner",
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "azure-function",
+            "WorkerTaskRunner",
+            "__init__.py",
+        ),
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["WorkerTaskRunner"] = module
+    spec.loader.exec_module(module)
+    return module, SBMessage
+
+
+def test_cleanup_invoked(monkeypatch):
+    os.environ["COSMOS_CONNECTION"] = "c"
+    os.environ["COSMOS_DATABASE"] = "db"
+    os.environ["REPO_CONTAINER"] = "r"
+    os.environ["TASK_CONTAINER"] = "t"
+    os.environ["SERVICEBUS_CONNECTION"] = "sb"
+    os.environ["SERVICEBUS_QUEUE"] = "q"
+    os.environ["ACI_RESOURCE_GROUP"] = "rg"
+    os.environ["ACI_SUBSCRIPTION_ID"] = "sub"
+
+    capture = {}
+    module, SBMessage = load_worker_task_runner(monkeypatch, capture)
+
+    event = WorkerTaskEvent(
+        timestamp=datetime.utcnow(),
+        source="t",
+        type="worker.task",
+        user_id="u",
+        metadata={"commands": ["echo"], "repo_url": "http://repo"},
+    )
+    msg = SBMessage(json.dumps(event.to_dict()))
+    module.main(msg)
+
+    assert capture.get("deleted") == capture.get("created")


### PR DESCRIPTION
## Summary
- clean up ACI container groups after sending task results
- test deletion of container groups when WorkerTaskRunner runs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447a11ee94832e8034a67bcb5be2f9