### PR TITLE
Add repo redirect route

### DIFF
--- a/chat_client/README.md
+++ b/chat_client/README.md
@@ -41,6 +41,7 @@ SESSION_SECRET=your-session-secret
 CHAINLIT_URL=https://localhost/chat  # For custom gateway URL
 EVENT_API_URL=https://your-function-app.azurewebsites.net/api/events
 AUTH_TOKEN=your-api-auth-token
+GITEA_URL=https://your-gitea-instance
 ```
 
 ## Local Development
@@ -119,6 +120,7 @@ chat_client/
 - `POST /chat/notify` - External message notifications
 - `GET /chat/health` - Health check
 - `GET /chat/dashboard` - Analytics dashboard
+- `GET /repo` - Redirect to the user's Gitea repository
 
 ## Security Features
 

--- a/chat_client/gateway_app.py
+++ b/chat_client/gateway_app.py
@@ -1,10 +1,15 @@
-from fastapi import FastAPI
+import os
+
+from fastapi import FastAPI, Request, HTTPException
 from starlette.responses import RedirectResponse
+from common.jwt_utils import verify_token
 
 from auth_app import app as auth_app
 from chainlit_app import fastapi_app as chat_app
 
 app = FastAPI(title="Lightning Chat Gateway")
+
+GITEA_URL = os.environ.get("GITEA_URL")
 
 # Mount the auth and chat applications under separate routes
 app.mount("/auth", auth_app)
@@ -18,3 +23,22 @@ async def root():
 @app.get("/health")
 async def health():
     return {"status": "ok"}
+
+
+@app.get("/repo", include_in_schema=False)
+async def repo_redirect(request: Request):
+    """Redirect the authenticated user to their Gitea repository."""
+    if not GITEA_URL:
+        raise HTTPException(status_code=404, detail="GITEA_URL not configured")
+
+    token = request.cookies.get("auth_token")
+    if not token:
+        return RedirectResponse(url="/auth/login")
+
+    try:
+        user_id = verify_token(token)
+    except Exception:
+        return RedirectResponse(url="/auth/login")
+
+    base = GITEA_URL.rstrip("/")
+    return RedirectResponse(url=f"{base}/{user_id}")

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -486,6 +486,12 @@ ui_container = containerinstance.ContainerGroup(
                         name="CHAINLIT_URL",
                         value=pulumi.Output.concat("https://", domain, "/chat"),
                     ),
+                    containerinstance.EnvironmentVariableArgs(
+                        name="GITEA_URL",
+                        value=gitea_container.ip_address.apply(
+                            lambda ip: f"http://{ip.fqdn}"
+                        ),
+                    ),
                 ],
                 resources=containerinstance.ResourceRequirementsArgs(
                     requests=containerinstance.ResourceRequestsArgs(cpu=1.0, memory_in_gb=1.0)


### PR DESCRIPTION
## Summary
- add `/repo` redirect in gateway app
- expose `GITEA_URL` in chat UI container
- document new variable and endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684479b59034832e9dd96ebd0fec7928