### PR TITLE
Remove ping tool from voice agent

### DIFF
--- a/agents/voice-agent/webapp/lib/tool-templates.ts
+++ b/agents/voice-agent/webapp/lib/tool-templates.ts
@@ -1,14 +1,5 @@
 export const toolTemplates = [
   {
-    name: "ping_no_args",
-    type: "function",
-    description: "A simple ping tool with no arguments",
-    parameters: {
-      type: "object",
-      properties: {},
-    },
-  },
-  {
     name: "get_user_nested_args",
     type: "function",
     description: "Fetch user profile by nested identifier",


### PR DESCRIPTION
## Summary
- remove the simple ping tool from the voice agent example

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6845a2a992b4832e80bf3f6da541c3de