### PR TITLE
Update requirements installation instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,13 @@ running either script.
 
 Both scripts require the `firecrawl-py` package which is listed in
 `requirements-worker.txt`.
+
+## Setup
+
+Before running tasks in this repository, install the Python dependencies with:
+
+```bash
+pip install -r requirements-worker.txt
+```
+
+Run this command from the project root so all utilities work correctly.

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -4,3 +4,4 @@ openai>=1.0.0
 # Additional dependencies that might be needed by agents
 requests
 firecrawl-py>=1.0.0
+fastapi


### PR DESCRIPTION
## Summary
- instruct to `pip install -r requirements-worker.txt`
- add `fastapi` as a dependency

## Testing
- `pip install -r requirements-worker.txt`

------
https://chatgpt.com/codex/tasks/task_e_6845a3b4435c832e96f9267fb04c9354