### PR TITLE
Add logging pipeline for voice agent

### DIFF
--- a/agents/voice-agent/README.md
+++ b/agents/voice-agent/README.md
@@ -98,6 +98,8 @@ TWILIO_AUTH_TOKEN="<twilio-auth-token>"
 COSMOS_CONNECTION="<connection-string>"
 COSMOS_DATABASE="vextir"
 USER_CONTAINER="users"
+LOG_CONTAINER="logs"
+REPO_CONTAINER="repos"
 ```
 
 The Cosmos variables allow the server to look up callers in the `users` container
@@ -118,6 +120,8 @@ Make note of the `Forwarding` URL. (e.g. `https://54c5-35-170-32-42.ngrok-free.a
 ### Websocket URL
 
 Your server should now be accessible at the `Forwarding` URL when run, so set the `PUBLIC_URL` in `websocket-server/.env`. See `websocket-server/.env.example` for reference.
+
+All conversation events are written to the Cosmos DB container specified by `LOG_CONTAINER`. When a call ends, the complete transcript is saved to the user's Gitea repository in the container defined by `REPO_CONTAINER`.
 
 # Additional Notes
 

--- a/agents/voice-agent/websocket-server/src/callControl.ts
+++ b/agents/voice-agent/websocket-server/src/callControl.ts
@@ -6,6 +6,10 @@ export function setCallSid(sid: string | undefined) {
   callSid = sid;
 }
 
+export function getCallSid(): string | undefined {
+  return callSid;
+}
+
 const authHeader =
   TWILIO_ACCOUNT_SID && TWILIO_AUTH_TOKEN
     ?


### PR DESCRIPTION
## Summary
- store each Realtime event in Cosmos DB via `LOG_CONTAINER`
- record complete transcript in the user's repo using Gitea API
- expose `getCallSid` and finalize logs at call shutdown
- document new environment variables and logging behaviour

## Testing
- `pip install -r requirements-worker.txt`
- `pytest -q`
- `npx tsc` in `agents/voice-agent/websocket-server`

------
https://chatgpt.com/codex/tasks/task_e_6845b70b9a4c832eaedbb1c5b1ff94c8