### PR TITLE
Fix voice agent Dockerfile and verify Twilio webhook

### DIFF
--- a/agents/voice-agent/websocket-server/Dockerfile
+++ b/agents/voice-agent/websocket-server/Dockerfile
@@ -1,9 +1,11 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --omit=dev
+# install all dependencies including devDependencies so TypeScript
+# compilation succeeds during the image build
+RUN npm ci
 COPY src ./src
 COPY tsconfig.json ./tsconfig.json
-RUN npx tsc
+RUN npx tsc && cp src/twiml.xml dist/
 EXPOSE 8081
 CMD ["node","dist/server.js"]


### PR DESCRIPTION
## Summary
- install dev dependencies for websocket-server image
- copy `twiml.xml` into the built image

Verified Twilio requested `/twiml` when a call was placed. The call event logs show the webhook URL `http://voiceagent30271.centralindia.azurecontainer.io:8081/twiml` returned TwiML with the streaming WebSocket URL.

## Testing
- `pip install -r requirements-worker.txt`
- `curl .../IncomingPhoneNumbers.json`
- `az acr build -t voiceagent:v2 -r lightningacr agents/voice-agent/websocket-server`
- `az container create ...`
- `curl -X POST https://api.twilio.com/.../Calls.json`
- `az container delete --resource-group lightning_dev-1 --name voiceagenttest --yes`


------
https://chatgpt.com/codex/tasks/task_e_6845b49afdd8832ea992db1720473407