### PR TITLE
Fix dashboard auth

### DIFF
--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -5,3 +5,4 @@ openai>=1.0.0
 requests
 firecrawl-py>=1.0.0
 fastapi
+jinja2>=3.1.0


### PR DESCRIPTION
## Summary
- use Authorization header or cookie token for dashboard
- remove unused username/password login
- add jinja2 to dependencies for tests

## Testing
- `pip install -r requirements-worker.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c4641928832eb4304d13cca05c63