### PR TITLE
Enable email verification via Azure Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,9 @@ USER_CONTAINER=users
 REPO_CONTAINER=repos
 SCHEDULE_CONTAINER=schedules
 TASK_CONTAINER=tasks
+ACS_CONNECTION=<acs-connection>
+ACS_SENDER=no-reply@example.com
+VERIFY_BASE_URL=https://localhost
 AUTH_TOKEN=<jwt-token>
 ```
 

--- a/azure-function/UserAuth/__init__.py
+++ b/azure-function/UserAuth/__init__.py
@@ -1,0 +1,96 @@
+import os
+import json
+import secrets
+import hashlib
+from datetime import datetime
+
+import azure.functions as func
+from azure.cosmos import CosmosClient, PartitionKey
+from azure.communication.email import EmailClient
+
+
+COSMOS_CONN = os.environ.get("COSMOS_CONNECTION")
+COSMOS_DB = os.environ.get("COSMOS_DATABASE", "vextir")
+USER_CONTAINER = os.environ.get("USER_CONTAINER", "users")
+ACS_CONNECTION = os.environ.get("ACS_CONNECTION")
+ACS_SENDER = os.environ.get("ACS_SENDER")
+VERIFY_BASE = os.environ.get("VERIFY_BASE_URL", "")
+
+_client = CosmosClient.from_connection_string(COSMOS_CONN)
+_db = _client.create_database_if_not_exists(COSMOS_DB)
+_container = _db.create_container_if_not_exists(id=USER_CONTAINER, partition_key=PartitionKey(path="/pk"))
+_email_client = EmailClient.from_connection_string(ACS_CONNECTION) if ACS_CONNECTION else None
+
+
+def _hash_password(password: str, salt: str) -> str:
+    return hashlib.sha256((salt + password).encode()).hexdigest()
+
+
+def _send_verification(email: str, token: str) -> None:
+    if not _email_client:
+        return
+    sender = ACS_SENDER or f"no-reply@{email.split('@')[1]}"
+    link = f"{VERIFY_BASE.rstrip('/')}/api/auth/verify?token={token}"
+    message = {
+        "senderAddress": sender,
+        "content": {"subject": "Verify your email", "plainText": f"Click to verify: {link}"},
+        "recipients": {"to": [{"address": email}]},
+    }
+    try:
+        _email_client.begin_send(message)
+    except Exception:
+        pass
+
+
+def _register(data: dict) -> func.HttpResponse:
+    username = data.get("username")
+    password = data.get("password")
+    email = data.get("email")
+    if not all([username, password, email]):
+        return func.HttpResponse("missing fields", status_code=400)
+    salt = secrets.token_hex(8)
+    token = secrets.token_urlsafe(16)
+    entity = {
+        "id": "user",
+        "pk": username,
+        "hash": _hash_password(password, salt),
+        "salt": salt,
+        "email": email,
+        "status": "waitlist",
+        "verify_token": token,
+        "created_at": datetime.utcnow().isoformat(),
+    }
+    _container.upsert_item(entity)
+    _send_verification(email, token)
+    return func.HttpResponse("", status_code=201)
+
+
+def _verify(token: str) -> func.HttpResponse:
+    if not token:
+        return func.HttpResponse("missing token", status_code=400)
+    items = list(_container.query_items(
+        query="SELECT * FROM c WHERE c.id='user' AND c.verify_token=@t",
+        parameters=[{"name": "@t", "value": token}],
+        enable_cross_partition_query=True,
+    ))
+    if not items:
+        return func.HttpResponse("invalid token", status_code=404)
+    user = items[0]
+    user.pop("verify_token", None)
+    user["email_verified"] = True
+    _container.upsert_item(user)
+    return func.HttpResponse("verified", status_code=200)
+
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    action = req.route_params.get("action")
+    if action == "register" and req.method == "POST":
+        try:
+            data = req.get_json()
+        except ValueError:
+            data = {}
+        return _register(data)
+    if action == "verify":
+        token = req.params.get("token")
+        return _verify(token)
+    return func.HttpResponse("not found", status_code=404)

--- a/azure-function/UserAuth/function.json
+++ b/azure-function/UserAuth/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get", "post"],
+      "route": "auth/{action}"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/tests/test_user_auth.py
+++ b/tests/test_user_auth.py
@@ -1,0 +1,110 @@
+import os
+import sys
+import types
+import importlib.util
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def load_user_auth(monkeypatch, capture):
+    azure_mod = types.ModuleType('azure')
+
+    # cosmos stub
+    cosmos_mod = types.ModuleType('cosmos')
+
+    class DummyContainer:
+        def __init__(self):
+            self.items = []
+        def upsert_item(self, item):
+            found = False
+            for i, it in enumerate(self.items):
+                if it['pk'] == item['pk']:
+                    self.items[i] = item
+                    found = True
+                    break
+            if not found:
+                self.items.append(item)
+        def query_items(self, query=None, parameters=None, enable_cross_partition_query=None):
+            token = parameters[0]['value']
+            return [i for i in self.items if i.get('verify_token') == token]
+
+    class DummyDatabase:
+        def __init__(self):
+            self.container = DummyContainer()
+        def create_container_if_not_exists(self, *a, **k):
+            return self.container
+
+    class DummyClient:
+        def __init__(self):
+            self.db = DummyDatabase()
+        def create_database_if_not_exists(self, *a, **k):
+            return self.db
+
+    cosmos_mod.CosmosClient = types.SimpleNamespace(from_connection_string=lambda *a, **k: DummyClient())
+    cosmos_mod.PartitionKey = lambda path: {'path': path}
+    azure_mod.cosmos = cosmos_mod
+
+    # functions stub
+    func_mod = types.ModuleType('functions')
+
+    class DummyRequest:
+        def __init__(self, method='GET', body=None, params=None, route_params=None):
+            self.method = method
+            self._body = body or {}
+            self.params = params or {}
+            self.route_params = route_params or {}
+        def get_json(self):
+            return self._body
+    class DummyResponse:
+        def __init__(self, body='', status_code=200):
+            self.body = body
+            self.status_code = status_code
+    func_mod.HttpRequest = DummyRequest
+    func_mod.HttpResponse = DummyResponse
+    azure_mod.functions = func_mod
+
+    # email stub
+    comm_mod = types.ModuleType('communication')
+    email_mod = types.ModuleType('email')
+    class DummyEmailClient:
+        def __init__(self, conn):
+            capture['conn'] = conn
+        def begin_send(self, message):
+            capture['message'] = message
+    email_mod.EmailClient = DummyEmailClient
+    email_mod.EmailClient.from_connection_string = classmethod(lambda cls, conn: cls(conn))
+    comm_mod.email = email_mod
+    azure_mod.communication = comm_mod
+
+    monkeypatch.setitem(sys.modules, 'azure', azure_mod)
+    monkeypatch.setitem(sys.modules, 'azure.functions', func_mod)
+    monkeypatch.setitem(sys.modules, 'azure.cosmos', cosmos_mod)
+    monkeypatch.setitem(sys.modules, 'azure.communication.email', email_mod)
+
+    spec = importlib.util.spec_from_file_location('UserAuth', os.path.join(os.path.dirname(__file__), '..', 'azure-function', 'UserAuth', '__init__.py'))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['UserAuth'] = module
+    spec.loader.exec_module(module)
+    return module, DummyRequest, DummyResponse
+
+
+def test_registration_sends_email_and_verifies(monkeypatch):
+    os.environ['COSMOS_CONNECTION'] = 'c'
+    os.environ['ACS_CONNECTION'] = 'conn'
+    os.environ['VERIFY_BASE_URL'] = 'http://host'
+    os.environ['ACS_SENDER'] = 'noreply@test.com'
+    capture = {}
+
+    module, Req, Resp = load_user_auth(monkeypatch, capture)
+
+    req = Req(method='POST', body={'username': 'u', 'password': 'pw', 'email': 'e@test.com'}, route_params={'action': 'register'})
+    resp = module.main(req)
+    assert resp.status_code == 201
+    assert capture['message']['senderAddress'] == 'noreply@test.com'
+    token = module._container.items[0]['verify_token']
+    assert token in capture['message']['content']['plainText']
+
+    req2 = Req(method='GET', params={'token': token}, route_params={'action': 'verify'})
+    resp2 = module.main(req2)
+    assert resp2.status_code == 200
+    assert module._container.items[0]['email_verified']


### PR DESCRIPTION
## Summary
- add UserAuth Azure Function to handle registration and email verification
- configure sample env to include email variables
- cover registration and verification logic with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845ed003a88832e992ed22cefceaa54