### PR TITLE
Switch GitHub secrets to ARM vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,9 +37,9 @@ jobs:
           pulumi config set aadTenantId "$AAD_TENANT_ID"
         working-directory: infra
         env:
-          AAD_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AAD_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AAD_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AAD_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          AAD_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          AAD_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       - name: Configure OpenAI API key
         run: pulumi config set openaiApiKey "${{ secrets.OPENAI_API_KEY }}" --secret
@@ -184,9 +184,9 @@ jobs:
           pulumi config set aadTenantId "$AAD_TENANT_ID"
         working-directory: infra
         env:
-          AAD_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AAD_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AAD_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AAD_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          AAD_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          AAD_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       - name: Configure OpenAI API key
         run: pulumi config set openaiApiKey "${{ secrets.OPENAI_API_KEY }}" --secret

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,18 @@
 The following secrets are available
 
-AZURE_SUBSCRIPTION_ID
-AZURE_CLIENT_SECRET
-AZURE_TENANT_ID
-AZURE_CLIENT_ID
+ARM_SUBSCRIPTION_ID
+ARM_CLIENT_SECRET
+ARM_TENANT_ID
+ARM_CLIENT_ID
 
 You can gain the use of az cli with the following preamble
 
 az login --service-principal \
-  --username "$AZURE_CLIENT_ID" \
-  --password "$AZURE_CLIENT_SECRET" \
-  --tenant "$AZURE_TENANT_ID"
+  --username "$ARM_CLIENT_ID" \
+  --password "$ARM_CLIENT_SECRET" \
+  --tenant "$ARM_TENANT_ID"
 
-az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+az account set --subscription "$ARM_SUBSCRIPTION_ID"
 
 If you need az, you will first need to install the cli using:
 

--- a/chat_client/auth_app.py
+++ b/chat_client/auth_app.py
@@ -11,9 +11,21 @@ from starlette.middleware.sessions import SessionMiddleware
 import msal
 from common.jwt_utils import verify_token
 
-AAD_CLIENT_ID = os.environ.get("AAD_CLIENT_ID") or os.environ.get("AZURE_CLIENT_ID")
-AAD_TENANT_ID = os.environ.get("AAD_TENANT_ID") or os.environ.get("AZURE_TENANT_ID")
-AAD_CLIENT_SECRET = os.environ.get("AAD_CLIENT_SECRET") or os.environ.get("AZURE_CLIENT_SECRET")
+AAD_CLIENT_ID = (
+    os.environ.get("AAD_CLIENT_ID")
+    or os.environ.get("ARM_CLIENT_ID")
+    or os.environ.get("AZURE_CLIENT_ID")
+)
+AAD_TENANT_ID = (
+    os.environ.get("AAD_TENANT_ID")
+    or os.environ.get("ARM_TENANT_ID")
+    or os.environ.get("AZURE_TENANT_ID")
+)
+AAD_CLIENT_SECRET = (
+    os.environ.get("AAD_CLIENT_SECRET")
+    or os.environ.get("ARM_CLIENT_SECRET")
+    or os.environ.get("AZURE_CLIENT_SECRET")
+)
 SESSION_SECRET = os.environ.get("SESSION_SECRET", "change-me")
 
 if not (AAD_CLIENT_ID and AAD_TENANT_ID and AAD_CLIENT_SECRET):

--- a/common/jwt_utils.py
+++ b/common/jwt_utils.py
@@ -28,8 +28,16 @@ def verify_token(token_or_header: str) -> str:
         token = token_or_header.split(" ", 1)[1]
 
     key = os.environ.get("JWT_SIGNING_KEY")
-    tenant = os.environ.get("AAD_TENANT_ID") or os.environ.get("AZURE_TENANT_ID")
-    client_id = os.environ.get("AAD_CLIENT_ID") or os.environ.get("AZURE_CLIENT_ID")
+    tenant = (
+        os.environ.get("AAD_TENANT_ID")
+        or os.environ.get("ARM_TENANT_ID")
+        or os.environ.get("AZURE_TENANT_ID")
+    )
+    client_id = (
+        os.environ.get("AAD_CLIENT_ID")
+        or os.environ.get("ARM_CLIENT_ID")
+        or os.environ.get("AZURE_CLIENT_ID")
+    )
 
     if key:
         options = {"require": ["exp"]}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,7 +11,7 @@ from common.jwt_utils import verify_token
 
 def test_expired_token(monkeypatch):
     os.environ['JWT_SIGNING_KEY'] = 'k'
-    for var in ['AAD_CLIENT_ID', 'AAD_TENANT_ID', 'AZURE_CLIENT_ID', 'AZURE_TENANT_ID']:
+    for var in ['AAD_CLIENT_ID', 'AAD_TENANT_ID', 'ARM_CLIENT_ID', 'ARM_TENANT_ID', 'AZURE_CLIENT_ID', 'AZURE_TENANT_ID']:
         monkeypatch.delenv(var, raising=False)
     token = jwt.encode({'sub': 'u', 'exp': time.time() - 10}, 'k')
     with pytest.raises(ValueError):
@@ -20,7 +20,7 @@ def test_expired_token(monkeypatch):
 
 def test_invalid_issuer(monkeypatch):
     os.environ['JWT_SIGNING_KEY'] = 'k'
-    for var in ['AAD_CLIENT_ID', 'AAD_TENANT_ID', 'AZURE_CLIENT_ID', 'AZURE_TENANT_ID']:
+    for var in ['AAD_CLIENT_ID', 'AAD_TENANT_ID', 'ARM_CLIENT_ID', 'ARM_TENANT_ID', 'AZURE_CLIENT_ID', 'AZURE_TENANT_ID']:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv('ISSUER', 'good')
     token = jwt.encode({'sub': 'u', 'exp': time.time() + 60, 'iss': 'bad'}, 'k')
@@ -30,7 +30,7 @@ def test_invalid_issuer(monkeypatch):
 
 def test_valid_token(monkeypatch):
     os.environ['JWT_SIGNING_KEY'] = 'k'
-    for var in ['AAD_CLIENT_ID', 'AAD_TENANT_ID', 'AZURE_CLIENT_ID', 'AZURE_TENANT_ID']:
+    for var in ['AAD_CLIENT_ID', 'AAD_TENANT_ID', 'ARM_CLIENT_ID', 'ARM_TENANT_ID', 'AZURE_CLIENT_ID', 'AZURE_TENANT_ID']:
         monkeypatch.delenv(var, raising=False)
     os.environ.pop('ISSUER', None)
     token = jwt.encode({'sub': 'u1', 'exp': time.time() + 60}, 'k')
@@ -39,7 +39,7 @@ def test_valid_token(monkeypatch):
 
 def test_missing_signing_key(monkeypatch):
     os.environ.pop('JWT_SIGNING_KEY', None)
-    for var in ['AAD_CLIENT_ID', 'AAD_TENANT_ID', 'AZURE_CLIENT_ID', 'AZURE_TENANT_ID']:
+    for var in ['AAD_CLIENT_ID', 'AAD_TENANT_ID', 'ARM_CLIENT_ID', 'ARM_TENANT_ID', 'AZURE_CLIENT_ID', 'AZURE_TENANT_ID']:
         monkeypatch.delenv(var, raising=False)
     with pytest.raises(RuntimeError):
         verify_token('tok')
@@ -47,7 +47,7 @@ def test_missing_signing_key(monkeypatch):
 
 def test_missing_user_id(monkeypatch):
     os.environ['JWT_SIGNING_KEY'] = 'k'
-    for var in ['AAD_CLIENT_ID', 'AAD_TENANT_ID', 'AZURE_CLIENT_ID', 'AZURE_TENANT_ID']:
+    for var in ['AAD_CLIENT_ID', 'AAD_TENANT_ID', 'ARM_CLIENT_ID', 'ARM_TENANT_ID', 'AZURE_CLIENT_ID', 'AZURE_TENANT_ID']:
         monkeypatch.delenv(var, raising=False)
     token = jwt.encode({'exp': time.time() + 60}, 'k')
     with pytest.raises(ValueError):
@@ -57,7 +57,7 @@ def test_missing_user_id(monkeypatch):
 
 def test_missing_token(monkeypatch):
     os.environ['JWT_SIGNING_KEY'] = 'k'
-    for var in ['AAD_CLIENT_ID', 'AAD_TENANT_ID', 'AZURE_CLIENT_ID', 'AZURE_TENANT_ID']:
+    for var in ['AAD_CLIENT_ID', 'AAD_TENANT_ID', 'ARM_CLIENT_ID', 'ARM_TENANT_ID', 'AZURE_CLIENT_ID', 'AZURE_TENANT_ID']:
         monkeypatch.delenv(var, raising=False)
     with pytest.raises(ValueError):
         verify_token('')


### PR DESCRIPTION
## Summary
- use `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, and `ARM_TENANT_ID` secrets in `deploy.yml`
- allow `chat_client` and JWT utils to read ARM variables
- update tests for ARM variables
- document ARM secrets in `AGENTS.md`

## Testing
- `pip install -r requirements-worker.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470403c928832eb5f028792ef24bd2