### PR TITLE
Add auth handling in Context Hub

### DIFF
--- a/context-hub/README.md
+++ b/context-hub/README.md
@@ -8,6 +8,10 @@ This directory contains a minimal Rust implementation of the Context Hub service
 cargo run
 ```
 
+All API calls require an `X-User-Id` HTTP header identifying the current user.
+An optional `X-Agent-Id` header can be supplied when the request originates from
+an agent acting on behalf of the user.
+
 The server exposes the following endpoints:
 
 - `GET /health` – simple health check returning `OK`.


### PR DESCRIPTION
## Summary
- add `AuthContext` extractor to pull `X-User-Id` and optional `X-Agent-Id`
- require headers in API handlers
- document header requirements in README

## Testing
- `cargo test --manifest-path context-hub/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_684733cd736c832eb320a5e34c3bdaab