### PR TITLE
Add owner metadata to Context Hub documents

### DIFF
--- a/context-hub/README.md
+++ b/context-hub/README.md
@@ -20,4 +20,4 @@ The server exposes the following endpoints:
 - `PUT /docs/:id` – replace document text. Body: `{ "content": "text" }`.
 - `DELETE /docs/:id` – remove a document.
 
-Documents are stored as Automerge CRDTs and persisted as binary files under the `data` directory.
+Documents are stored as Automerge CRDTs and persisted as binary files under the `data` directory. Each document carries an **owner**. When a document is created, the `X-User-Id` header value is recorded as its owner. Existing files loaded from disk default to the user `user1`. The API responses include this `owner` field.


### PR DESCRIPTION
## Summary
- add an owner field to Context Hub `Document`
- record the creating user as document owner via API
- default existing docs to user `user1`
- document the owner behaviour in the README

## Testing
- `cargo test --manifest-path context-hub/Cargo.toml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473663b598832ebe6e6a357037573c