### PR TITLE
Fix context-hub router path syntax

### DIFF
--- a/context-hub/src/api/mod.rs
+++ b/context-hub/src/api/mod.rs
@@ -66,7 +66,7 @@ pub fn router(state: Arc<Mutex<DocumentStore>>) -> Router {
     let app_state = AppState { store: state };
     Router::new()
         .route("/docs", post(create_doc))
-        .route("/docs/:id", get(get_doc).put(update_doc).delete(delete_doc))
+        .route("/docs/{id}", get(get_doc).put(update_doc).delete(delete_doc))
         .with_state(app_state)
 }
 


### PR DESCRIPTION
## Summary
- update axum router to use `{}` syntax for path captures

## Testing
- `pip install -r requirements-worker.txt`
- `cargo run --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684738eedbe0832eb34f7d9a3a398875