### PR TITLE
Enable named documents with folders

### DIFF
--- a/context-hub/src/api/mod.rs
+++ b/context-hub/src/api/mod.rs
@@ -72,7 +72,10 @@ pub fn router(state: Arc<Mutex<DocumentStore>>) -> Router {
     let app_state = AppState { store: state };
     Router::new()
         .route("/docs", post(create_doc))
-        .route("/docs/{id}", get(get_doc).put(update_doc).delete(delete_doc))
+        .route(
+            "/docs/{id}",
+            get(get_doc).put(update_doc).delete(delete_doc),
+        )
         .with_state(app_state)
 }
 
@@ -161,7 +164,10 @@ async fn delete_doc(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{body::{self, Body}, http::Request};
+    use axum::{
+        body::{self, Body},
+        http::Request,
+    };
     use serde_json::json;
     use tower::util::ServiceExt;
 
@@ -176,7 +182,9 @@ mod tests {
             .uri("/docs")
             .header("X-User-Id", "user1")
             .header("content-type", "application/json")
-            .body(Body::from(json!({"content": "hello"}).to_string()))
+            .body(Body::from(
+                json!({"name": "file.txt", "content": "hello"}).to_string(),
+            ))
             .unwrap();
         let resp = app.clone().oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
@@ -197,7 +205,9 @@ mod tests {
             .uri(format!("/docs/{}", id))
             .header("X-User-Id", "user1")
             .header("content-type", "application/json")
-            .body(Body::from(json!({"content": "world"}).to_string()))
+            .body(Body::from(
+                json!({"name": "file.txt", "content": "world"}).to_string(),
+            ))
             .unwrap();
         let resp = app.clone().oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::NO_CONTENT);

--- a/context-hub/tests/server.rs
+++ b/context-hub/tests/server.rs
@@ -1,17 +1,19 @@
-use context_hub::{api, storage};
 use axum::{routing::get, Router};
+use context_hub::{api, storage};
 use std::future::IntoFuture;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
-use std::time::Duration;
 
 #[tokio::test]
 async fn server_health_endpoint() {
     let tempdir = tempfile::tempdir().unwrap();
     let store = storage::crdt::DocumentStore::new(tempdir.path()).unwrap();
     let router = api::router(Arc::new(Mutex::new(store)));
-    let app = Router::new().merge(router).route("/health", get(|| async { "OK" }));
+    let app = Router::new()
+        .merge(router)
+        .route("/health", get(|| async { "OK" }));
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();


### PR DESCRIPTION
## Summary
- persist document metadata (name, owner, folder and type) in the CRDT
- allow DocumentStore::create to specify name and optional parent folder
- load metadata from storage on startup
- update API and tests to send the new fields

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68473bd46c80832eb9ee3987917c2e42