### PR TITLE
Add support for named document creation

### DIFF
--- a/context-hub/src/api/mod.rs
+++ b/context-hub/src/api/mod.rs
@@ -176,7 +176,17 @@ mod tests {
             .uri("/docs")
             .header("X-User-Id", "user1")
             .header("content-type", "application/json")
-            .body(Body::from(json!({"content": "hello"}).to_string()))
+            .body(
+                Body::from(
+                    json!({
+                        "name": "file.txt",
+                        "content": "hello",
+                        "parent_folder_id": null,
+                        "doc_type": "Text"
+                    })
+                    .to_string(),
+                ),
+            )
             .unwrap();
         let resp = app.clone().oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
@@ -197,7 +207,17 @@ mod tests {
             .uri(format!("/docs/{}", id))
             .header("X-User-Id", "user1")
             .header("content-type", "application/json")
-            .body(Body::from(json!({"content": "world"}).to_string()))
+            .body(
+                Body::from(
+                    json!({
+                        "name": "file.txt",
+                        "content": "world",
+                        "parent_folder_id": null,
+                        "doc_type": "Text"
+                    })
+                    .to_string(),
+                ),
+            )
             .unwrap();
         let resp = app.clone().oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::NO_CONTENT);

--- a/context-hub/src/storage/crdt/mod.rs
+++ b/context-hub/src/storage/crdt/mod.rs
@@ -259,7 +259,15 @@ mod tests {
     #[test]
     fn document_text_roundtrip() {
         let id = Uuid::new_v4();
-        let mut doc = Document::new(id, "hello", "user".to_string()).unwrap();
+        let mut doc = Document::new(
+            id,
+            "file.txt".to_string(),
+            "hello",
+            "user".to_string(),
+            None,
+            DocumentType::Text,
+        )
+        .unwrap();
         assert_eq!(doc.text(), "hello");
         doc.set_text("goodbye").unwrap();
         assert_eq!(doc.text(), "goodbye");
@@ -269,7 +277,15 @@ mod tests {
     fn store_persists_to_disk() {
         let tempdir = tempfile::tempdir().unwrap();
         let mut store = DocumentStore::new(tempdir.path()).unwrap();
-        let id = store.create("persist", "user1".to_string()).unwrap();
+        let id = store
+            .create(
+                "persist.txt".to_string(),
+                "persist",
+                "user1".to_string(),
+                None,
+                DocumentType::Text,
+            )
+            .unwrap();
         store.update(id, "changed").unwrap();
         drop(store);
 


### PR DESCRIPTION
## Summary
- refactor Document struct and store for names and folder links
- update API endpoint tests to send document names
- fix DocumentStore tests to include name and folder options

## Testing
- `cargo test -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473f113914832eb7307dc29368879c