### PR TITLE
Fix chat client dependencies

### DIFF
--- a/chat_client/Dockerfile
+++ b/chat_client/Dockerfile
@@ -12,17 +12,11 @@ COPY events/ ./events/
 COPY dashboard/ ./dashboard/
 COPY common/ ./common/
 
+# Copy Python dependencies
+COPY chat_client/requirements.txt ./requirements.txt
+
 # Install Python dependencies
-RUN pip install --no-cache-dir \
-    chainlit \
-    fastapi \
-    uvicorn \
-    requests \
-    jinja2 \
-    python-multipart \
-    python-jose[cryptography] \
-    PyJWT \
-    itsdangerous
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Make startup script executable
 RUN chmod +x ./start.sh


### PR DESCRIPTION
## Summary
- install `chat_client` dependencies from requirements file so `msal` is included

## Testing
- `pip install -r requirements-worker.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68474004d71c832eb160ac34c5cb6db2