### PR TITLE
Implement per-user root folders for Context Hub

### DIFF
--- a/context-hub/tests/server.rs
+++ b/context-hub/tests/server.rs
@@ -1,17 +1,20 @@
-use context_hub::{api, storage};
 use axum::{routing::get, Router};
+use context_hub::{api, storage};
 use std::future::IntoFuture;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
-use std::time::Duration;
+use tower::util::ServiceExt;
 
 #[tokio::test]
 async fn server_health_endpoint() {
     let tempdir = tempfile::tempdir().unwrap();
     let store = storage::crdt::DocumentStore::new(tempdir.path()).unwrap();
     let router = api::router(Arc::new(Mutex::new(store)));
-    let app = Router::new().merge(router).route("/health", get(|| async { "OK" }));
+    let app = Router::new()
+        .merge(router)
+        .route("/health", get(|| async { "OK" }));
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -26,4 +29,32 @@ async fn server_health_endpoint() {
     assert_eq!(text, "OK");
 
     server.abort();
+}
+
+#[tokio::test]
+async fn root_created_on_use() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let store = storage::crdt::DocumentStore::new(tempdir.path()).unwrap();
+    let shared = Arc::new(Mutex::new(store));
+    let app = Router::new().merge(api::router(shared.clone()));
+
+    let req = axum::http::Request::builder()
+        .method("POST")
+        .uri("/docs")
+        .header("X-User-Id", "newuser")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            serde_json::json!({
+                "name": "a.txt",
+                "content": "hi",
+                "parent_folder_id": null,
+                "doc_type": "Text"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let _ = app.clone().oneshot(req).await.unwrap();
+
+    let mut store = shared.lock().await;
+    assert!(store.ensure_root("newuser").is_ok());
 }


### PR DESCRIPTION
## Summary
- create per-user root folders in `DocumentStore`
- ensure API routes establish root folders
- test root folder creation in storage and server tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68474519f37c832eafe15b33ff7815d2