### PR TITLE
Implement snapshot repository initialization

### DIFF
--- a/context-hub/Cargo.lock
+++ b/context-hub/Cargo.lock
@@ -173,6 +173,8 @@ version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -195,6 +197,7 @@ dependencies = [
  "anyhow",
  "automerge",
  "axum",
+ "git2",
  "reqwest",
  "serde",
  "serde_json",
@@ -422,6 +425,21 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git2"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
 
 [[package]]
 name = "h2"
@@ -752,6 +770,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +800,46 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.16.2+1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"

--- a/context-hub/Cargo.toml
+++ b/context-hub/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = "1"
 automerge = "1.0.0-alpha.4"
 uuid = { version = "1", features = ["v4"] }
 anyhow = "1"
+git2 = "0.18"
 
 [dev-dependencies]
 tempfile = "3"

--- a/context-hub/src/lib.rs
+++ b/context-hub/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod api;
 pub mod storage;
+pub mod snapshot;

--- a/context-hub/src/main.rs
+++ b/context-hub/src/main.rs
@@ -5,9 +5,13 @@ use tokio::sync::Mutex;
 
 mod api;
 mod storage;
+mod snapshot;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // initialize snapshot repository for durability
+    let _snapshots = snapshot::SnapshotManager::new("snapshots")?;
+
     let store = storage::crdt::DocumentStore::new("data")?;
     let router = api::router(Arc::new(Mutex::new(store)));
     let app = Router::new()

--- a/context-hub/src/snapshot.rs
+++ b/context-hub/src/snapshot.rs
@@ -1,0 +1,26 @@
+use std::path::Path;
+
+use anyhow::Result;
+use git2::Repository;
+
+pub struct SnapshotManager {
+    repo: Repository,
+}
+
+impl SnapshotManager {
+    pub fn new(dir: impl AsRef<Path>) -> Result<Self> {
+        let dir = dir.as_ref();
+        let repo = if dir.join(".git").exists() {
+            Repository::open(dir)?
+        } else {
+            std::fs::create_dir_all(dir)?;
+            Repository::init(dir)?
+        };
+        Ok(Self { repo })
+    }
+
+    /// Placeholder for future snapshot logic
+    pub fn repo(&self) -> &Repository {
+        &self.repo
+    }
+}

--- a/context-hub/tests/snapshot.rs
+++ b/context-hub/tests/snapshot.rs
@@ -1,0 +1,9 @@
+use context_hub::snapshot::SnapshotManager;
+
+#[test]
+fn init_repo_creates_git_dir() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let path = tempdir.path();
+    SnapshotManager::new(path).unwrap();
+    assert!(path.join(".git").exists());
+}


### PR DESCRIPTION
## Summary
- add a SnapshotManager that sets up a git repository
- initialize SnapshotManager from `main.rs`
- wire new module into the library
- test repository creation

## Testing
- `pip install -r requirements-worker.txt`
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_68482dc8d490832eb4133e5fee33b49a