### PR TITLE
Implement snapshot save for Context Hub

### DIFF
--- a/context-hub/Cargo.lock
+++ b/context-hub/Cargo.lock
@@ -18,6 +18,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +200,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +224,7 @@ dependencies = [
  "anyhow",
  "automerge",
  "axum",
+ "chrono",
  "git2",
  "reqwest",
  "serde",
@@ -632,6 +660,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +974,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1736,6 +1797,65 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/context-hub/Cargo.toml
+++ b/context-hub/Cargo.toml
@@ -12,6 +12,7 @@ automerge = "1.0.0-alpha.4"
 uuid = { version = "1", features = ["v4"] }
 anyhow = "1"
 git2 = "0.18"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/context-hub/src/lib.rs
+++ b/context-hub/src/lib.rs
@@ -1,3 +1,3 @@
 pub mod api;
-pub mod storage;
 pub mod snapshot;
+pub mod storage;

--- a/context-hub/src/main.rs
+++ b/context-hub/src/main.rs
@@ -4,8 +4,8 @@ use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 
 mod api;
-mod storage;
 mod snapshot;
+mod storage;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/context-hub/src/snapshot.rs
+++ b/context-hub/src/snapshot.rs
@@ -1,7 +1,9 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use anyhow::Result;
-use git2::Repository;
+use crate::storage::crdt::DocumentStore;
+use anyhow::{anyhow, Result};
+use chrono::Utc;
+use git2::{IndexAddOption, Repository, Signature};
 
 pub struct SnapshotManager {
     repo: Repository,
@@ -19,7 +21,45 @@ impl SnapshotManager {
         Ok(Self { repo })
     }
 
-    /// Placeholder for future snapshot logic
+    /// Commit the current document store state to the snapshot repository.
+    pub fn snapshot(&self, store: &DocumentStore) -> Result<()> {
+        let workdir = self
+            .repo
+            .workdir()
+            .ok_or_else(|| anyhow!("snapshot repository has no working directory"))?;
+
+        // copy all document files into the repo workdir
+        for entry in std::fs::read_dir(store.data_dir())? {
+            let entry = entry?;
+            if entry.file_type()?.is_file() {
+                let dest = PathBuf::from(workdir).join(entry.file_name());
+                std::fs::copy(entry.path(), dest)?;
+            }
+        }
+
+        // stage all changes
+        let mut index = self.repo.index()?;
+        index.add_all(["*"].iter(), IndexAddOption::DEFAULT, None)?;
+        index.write()?;
+        let tree_id = index.write_tree()?;
+        let tree = self.repo.find_tree(tree_id)?;
+
+        let sig = Signature::now("context-hub", "context@hub")?;
+        let msg = format!("Snapshot {}", Utc::now().to_rfc3339());
+        let commit_id = match self.repo.head() {
+            Ok(head) => {
+                let parent = head.peel_to_commit()?;
+                self.repo
+                    .commit(Some("HEAD"), &sig, &sig, &msg, &tree, &[&parent])?
+            }
+            Err(_) => self
+                .repo
+                .commit(Some("HEAD"), &sig, &sig, &msg, &tree, &[])?,
+        };
+        let _ = commit_id; // suppress unused warning
+        Ok(())
+    }
+
     pub fn repo(&self) -> &Repository {
         &self.repo
     }

--- a/context-hub/src/storage/crdt/mod.rs
+++ b/context-hub/src/storage/crdt/mod.rs
@@ -399,6 +399,11 @@ impl DocumentStore {
         })
     }
 
+    /// Directory where documents are persisted.
+    pub fn data_dir(&self) -> &Path {
+        &self.dir
+    }
+
     fn path(&self, id: Uuid) -> PathBuf {
         self.dir.join(format!("{}.bin", id))
     }

--- a/context-hub/tests/snapshot.rs
+++ b/context-hub/tests/snapshot.rs
@@ -1,4 +1,5 @@
 use context_hub::snapshot::SnapshotManager;
+use context_hub::storage::crdt::{DocumentStore, DocumentType};
 
 #[test]
 fn init_repo_creates_git_dir() {
@@ -6,4 +7,28 @@ fn init_repo_creates_git_dir() {
     let path = tempdir.path();
     SnapshotManager::new(path).unwrap();
     assert!(path.join(".git").exists());
+}
+
+#[test]
+fn snapshot_commits_files() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let repo_dir = tempdir.path().join("repo");
+    let data_dir = tempdir.path().join("data");
+    let mut store = DocumentStore::new(&data_dir).unwrap();
+    store
+        .create(
+            "note.txt".to_string(),
+            "hi",
+            "user1".to_string(),
+            None,
+            DocumentType::Text,
+        )
+        .unwrap();
+
+    let mgr = SnapshotManager::new(&repo_dir).unwrap();
+    mgr.snapshot(&store).unwrap();
+
+    assert!(repo_dir.join(".git").exists());
+    let repo = git2::Repository::open(repo_dir).unwrap();
+    assert!(repo.revparse_single("HEAD").is_ok());
 }


### PR DESCRIPTION
## Summary
- extend DocumentStore with a `data_dir` getter
- add snapshot function to commit current state to Git
- wire up chrono dependency
- test snapshot commits

## Testing
- `pip install -r requirements-worker.txt`
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_684831b35b10832ea9a8047f39e7ae81