### PR TITLE
Add automatic snapshots to Context Hub

### DIFF
--- a/context-hub/src/main.rs
+++ b/context-hub/src/main.rs
@@ -2,6 +2,9 @@ use axum::{routing::get, serve, Router};
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
+use tokio::time::Duration;
+use tokio::task::LocalSet;
+use std::future::IntoFuture;
 
 mod api;
 mod snapshot;
@@ -10,16 +13,25 @@ mod storage;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // initialize snapshot repository for durability
-    let _snapshots = snapshot::SnapshotManager::new("snapshots")?;
+    let snapshot_mgr = Arc::new(snapshot::SnapshotManager::new("snapshots")?);
 
-    let store = storage::crdt::DocumentStore::new("data")?;
-    let router = api::router(Arc::new(Mutex::new(store)));
+    let store = Arc::new(Mutex::new(storage::crdt::DocumentStore::new("data")?));
+    let router = api::router(store.clone());
+    // spawn periodic snapshots every hour on a LocalSet so non-Send types work
+    let local = LocalSet::new();
+    local.spawn_local(snapshot::snapshot_task(
+        store.clone(),
+        snapshot_mgr.clone(),
+        Duration::from_secs(3600),
+    ));
     let app = Router::new()
         .merge(router)
         .route("/health", get(|| async { "OK" }));
 
     let listener = TcpListener::bind("127.0.0.1:3000").await?;
     println!("Listening on 127.0.0.1:3000");
-    serve(listener, app.into_make_service()).await?;
+    local
+        .run_until(serve(listener, app.into_make_service()).into_future())
+        .await?;
     Ok(())
 }

--- a/context-hub/tests/snapshot.rs
+++ b/context-hub/tests/snapshot.rs
@@ -1,5 +1,9 @@
 use context_hub::snapshot::SnapshotManager;
 use context_hub::storage::crdt::{DocumentStore, DocumentType};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::time::Duration;
+use tokio::task::LocalSet;
 
 #[test]
 fn init_repo_creates_git_dir() {
@@ -27,6 +31,37 @@ fn snapshot_commits_files() {
 
     let mgr = SnapshotManager::new(&repo_dir).unwrap();
     mgr.snapshot(&store).unwrap();
+
+    assert!(repo_dir.join(".git").exists());
+    let repo = git2::Repository::open(repo_dir).unwrap();
+    assert!(repo.revparse_single("HEAD").is_ok());
+}
+
+#[tokio::test]
+async fn snapshot_task_runs() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let repo_dir = tempdir.path().join("repo");
+    let data_dir = tempdir.path().join("data");
+    let store = Arc::new(Mutex::new(DocumentStore::new(&data_dir).unwrap()));
+    {
+        let mut s = store.lock().await;
+        s.create(
+            "note.txt".to_string(),
+            "hi",
+            "user1".to_string(),
+            None,
+            DocumentType::Text,
+        )
+        .unwrap();
+    }
+    let mgr = Arc::new(SnapshotManager::new(&repo_dir).unwrap());
+    let local = LocalSet::new();
+    local.spawn_local(context_hub::snapshot::snapshot_task(
+        store.clone(),
+        mgr.clone(),
+        Duration::from_millis(100),
+    ));
+    local.run_until(tokio::time::sleep(Duration::from_millis(150))).await;
 
     assert!(repo_dir.join(".git").exists());
     let repo = git2::Repository::open(repo_dir).unwrap();


### PR DESCRIPTION
## Summary
- track dirty state in `DocumentStore`
- implement async snapshot task
- use `LocalSet` in main to run snapshotting
- test periodic snapshots

## Testing
- `cargo test --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684833f22b58832e8c1d40ef528bca39