### PR TITLE
Fix AFD origin host names

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -985,7 +985,7 @@ if domain:
         profile_name=fd_profile.name,
         origin_group_name=ui_group.name,
         origin_name="uiOrigin",
-        host_name=ui_container.ip_address.apply(lambda ip: ip.fqdn),
+        host_name=ui_container.ip_address.apply(lambda ip: ip.ip),
     )
 
     api_group = cdn.afd_origin_group.AFDOriginGroup(
@@ -1039,7 +1039,7 @@ if domain:
         profile_name=fd_profile.name,
         origin_group_name=voice_group.name,
         origin_name="voiceOrigin",
-        host_name=voice_ws_container.ip_address.apply(lambda ip: ip.fqdn),
+        host_name=voice_ws_container.ip_address.apply(lambda ip: ip.ip),
         http_port=8081,
         https_port=8081,
     )


### PR DESCRIPTION
## Summary
- configure AFD origins to use container IPs instead of missing FQDNs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684836ff080c832e92699fb11845959e