### PR TITLE
Add manual snapshot trigger endpoint

### DIFF
--- a/context-hub/src/main.rs
+++ b/context-hub/src/main.rs
@@ -1,10 +1,11 @@
 use axum::{routing::get, serve, Router};
+use std::future::IntoFuture;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
-use tokio::time::Duration;
 use tokio::task::LocalSet;
-use std::future::IntoFuture;
+use tokio::time::Duration;
 
 mod api;
 mod snapshot;
@@ -16,7 +17,7 @@ async fn main() -> anyhow::Result<()> {
     let snapshot_mgr = Arc::new(snapshot::SnapshotManager::new("snapshots")?);
 
     let store = Arc::new(Mutex::new(storage::crdt::DocumentStore::new("data")?));
-    let router = api::router(store.clone());
+    let router = api::router(store.clone(), PathBuf::from("snapshots"));
     // spawn periodic snapshots every hour on a LocalSet so non-Send types work
     let local = LocalSet::new();
     local.spawn_local(snapshot::snapshot_task(

--- a/context-hub/tests/server.rs
+++ b/context-hub/tests/server.rs
@@ -11,7 +11,7 @@ use tower::util::ServiceExt;
 async fn server_health_endpoint() {
     let tempdir = tempfile::tempdir().unwrap();
     let store = storage::crdt::DocumentStore::new(tempdir.path()).unwrap();
-    let router = api::router(Arc::new(Mutex::new(store)));
+    let router = api::router(Arc::new(Mutex::new(store)), tempdir.path().into());
     let app = Router::new()
         .merge(router)
         .route("/health", get(|| async { "OK" }));
@@ -36,7 +36,7 @@ async fn root_created_on_use() {
     let tempdir = tempfile::tempdir().unwrap();
     let store = storage::crdt::DocumentStore::new(tempdir.path()).unwrap();
     let shared = Arc::new(Mutex::new(store));
-    let app = Router::new().merge(api::router(shared.clone()));
+    let app = Router::new().merge(api::router(shared.clone(), tempdir.path().into()));
 
     let req = axum::http::Request::builder()
         .method("POST")


### PR DESCRIPTION
## Summary
- expose `/snapshot` endpoint to trigger a snapshot on demand
- adapt server and tests for new parameter
- add regression test for snapshot endpoint

## Testing
- `pip install -r requirements-worker.txt`
- `cargo test --manifest-path context-hub/Cargo.toml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483739eb2c832ebe1f10b808f5dc9b