### PR TITLE
Implement snapshot restore capability

### DIFF
--- a/context-hub/src/storage/crdt/mod.rs
+++ b/context-hub/src/storage/crdt/mod.rs
@@ -406,6 +406,13 @@ impl DocumentStore {
         &self.dir
     }
 
+    /// Reload the store contents from disk, discarding any in-memory state.
+    pub fn reload(&mut self) -> Result<()> {
+        let new_self = Self::new(&self.dir)?;
+        *self = new_self;
+        Ok(())
+    }
+
     /// Return whether the store has un-snapshotted changes.
     pub fn is_dirty(&self) -> bool {
         self.dirty


### PR DESCRIPTION
## Summary
- extend snapshot manager with restore capability
- add DocumentStore reload method
- expose new `/restore` endpoint
- cover new functionality with unit test

## Testing
- `pip install -r requirements-worker.txt`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68483fc9d560832e8ec0b00cd2a53c1a