### PR TITLE
Add CRDT history compaction

### DIFF
--- a/context-hub/src/api/mod.rs
+++ b/context-hub/src/api/mod.rs
@@ -426,6 +426,7 @@ async fn snapshot_now(State(state): State<AppState>, _auth: AuthContext) -> Stat
     match mgr.snapshot(&store) {
         Ok(_) => {
             store.clear_dirty();
+            let _ = store.compact_history();
             StatusCode::NO_CONTENT
         }
         Err(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/context-hub/src/snapshot.rs
+++ b/context-hub/src/snapshot.rs
@@ -6,7 +6,7 @@ use tokio::time::{interval, Duration};
 use crate::storage::crdt::DocumentStore;
 use anyhow::{anyhow, Result};
 use chrono::{TimeZone, Utc};
-use git2::{IndexAddOption, ObjectType, Repository, Signature, Oid};
+use git2::{IndexAddOption, ObjectType, Oid, Repository, Signature};
 
 pub struct SnapshotManager {
     repo: Repository,
@@ -79,7 +79,10 @@ impl SnapshotManager {
             for id in walk {
                 let id = id?;
                 let commit = self.repo.find_commit(id)?;
-                let commit_time = Utc.timestamp_opt(commit.time().seconds(), 0).single().unwrap();
+                let commit_time = Utc
+                    .timestamp_opt(commit.time().seconds(), 0)
+                    .single()
+                    .unwrap();
                 if commit_time <= ts {
                     found = Some(id);
                     break;
@@ -129,6 +132,7 @@ pub async fn snapshot_task(
         if store.is_dirty() {
             let _ = manager.snapshot(&store);
             store.clear_dirty();
+            let _ = store.compact_history();
         }
     }
 }


### PR DESCRIPTION
## Summary
- provide `Document::reload` to refresh Automerge state from disk
- add `DocumentStore::compact_history` to purge CRDT op logs
- invoke compaction after snapshots in background task and API

## Testing
- `cargo test`
- `pip install -r requirements-worker.txt`

------
https://chatgpt.com/codex/tasks/task_e_6848435facc4832ebff013ed872b0904