### PR TITLE
Set location for frontdoor profile

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -953,6 +953,7 @@ if domain:
     fd_profile = cdn.Profile(
         "frontdoor-profile",
         resource_group_name=resource_group.name,
+        location="global",
         profile_name="vextir-fd",
         sku=cdn.SkuArgs(name=cdn.SkuName.STANDARD_AZURE_FRONT_DOOR),
     )


### PR DESCRIPTION
## Summary
- set `location` on the Azure Front Door profile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684848653414832eaaafae2b9f301f1b