### PR TITLE
Fix DNS label collisions

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -57,7 +57,9 @@ twilio_auth_token = config.require_secret("twilioAuthToken")
 voice_ws_image = config.get("voiceWsImage") or "vextiracr.azurecr.io/voice-ws:latest"
 
 # Generate a stable random suffix for DNS labels if not provided via config.
-dns_suffix = RandomString("dns-suffix", length=8, special=False, upper=False).result
+# Increase the length to reduce the chance of collisions when allocating
+# public DNS labels for container groups.
+dns_suffix = RandomString("dns-suffix", length=12, special=False, upper=False).result
 
 ui_dns_label = config.get("uiDnsLabel") or pulumi.Output.concat("chat-ui-", dns_suffix)
 voice_dns_label = config.get("voiceDnsLabel") or pulumi.Output.concat("voice-ws-", dns_suffix)


### PR DESCRIPTION
## Summary
- generate a longer random DNS suffix to lower chance of collisions

## Testing
- `pip install -r requirements-worker.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684874832974832ea822bead4a812fa1