### PR TITLE
Fix folder detection in context hub Document load

### DIFF
--- a/context-hub/src/storage/crdt/mod.rs
+++ b/context-hub/src/storage/crdt/mod.rs
@@ -250,7 +250,7 @@ impl Document {
         let doc = LoroDoc::new();
         doc.import(&bytes).map_err(|e| anyhow!(e))?;
         doc.commit();
-        let doc_type = if doc.get_map(CHILDREN_KEY).is_attached() {
+        let doc_type = if doc.get_by_str_path(CHILDREN_KEY).is_some() {
             DocumentType::Folder
         } else if let Some(t) = doc
             .get_by_str_path("meta/doc_type")


### PR DESCRIPTION
## Summary
- avoid creating empty children map when loading documents

## Testing
- `cargo test --manifest-path context-hub/Cargo.toml --lib -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6849cd890f58832ea416e62c7ac8b93a