### PR TITLE
Add real-time events stream

### DIFF
--- a/context-hub/Cargo.lock
+++ b/context-hub/Cargo.lock
@@ -146,6 +146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -165,8 +166,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -221,6 +224,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +257,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8c7d2ac73c167c06af4a5f37e6e59d84148d57ccbe4480b76f0273eefea82d7"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -325,6 +343,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "futures",
  "git2",
  "loro",
  "reqwest",
@@ -333,6 +352,7 @@ dependencies = [
  "tantivy",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tower",
  "uuid",
 ]
@@ -352,6 +372,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -409,6 +438,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +483,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +514,16 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -580,7 +635,7 @@ checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
 dependencies = [
  "log",
  "once_cell",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -650,12 +705,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -663,6 +734,34 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.102",
+]
 
 [[package]]
 name = "futures-sink"
@@ -682,10 +781,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -709,6 +814,16 @@ dependencies = [
  "log",
  "rustversion",
  "windows",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1155,7 +1270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
 dependencies = [
  "bitmaps",
- "rand_core",
+ "rand_core 0.6.4",
  "rand_xoshiro",
  "serde",
  "sized-chunks",
@@ -1382,7 +1497,7 @@ dependencies = [
  "serde",
  "serde_columnar",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1429,12 +1544,12 @@ dependencies = [
  "once_cell",
  "postcard",
  "pretty_assertions",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_columnar",
  "serde_json",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "thread_local",
  "tracing",
  "wasm-bindgen",
@@ -1482,7 +1597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e387a04d7d6a74ebb3434c906c84ddcae4413e5ef8bcd8e7d5138959d416a512"
 dependencies = [
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -1930,8 +2045,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1941,7 +2066,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1954,12 +2089,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2209,7 +2353,7 @@ dependencies = [
  "postcard",
  "serde",
  "serde_columnar_derive",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2267,6 +2411,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2470,7 +2625,7 @@ dependencies = [
  "tantivy-fst",
  "tantivy-query-grammar",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "uuid",
  "winapi",
@@ -2533,7 +2688,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2541,6 +2705,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.102",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2635,6 +2810,30 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -2747,6 +2946,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.9.1",
+ "sha1",
+ "thiserror 2.0.12",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,6 +2994,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-ranges"

--- a/context-hub/Cargo.toml
+++ b/context-hub/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -14,6 +14,8 @@ anyhow = "1"
 git2 = "0.18"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 tantivy = { version = "0.19", default-features = false, features = ["lz4-compression", "mmap"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
+futures = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/context-hub/README.md
+++ b/context-hub/README.md
@@ -23,6 +23,7 @@ The server exposes the following endpoints:
 - `GET /folders/:id/guide` – retrieve the Index Guide for a folder.
 - `GET /search?q=term` – search documents using a keyword query. Returns only
   results the caller has permission to read.
+- `GET /ws` – subscribe to a server-sent events stream of document changes.
 
 Documents are stored as Automerge CRDTs and persisted as binary files under the `data` directory. Each document carries an **owner**. When a document is created, the `X-User-Id` header value is recorded as its owner. Existing files loaded from disk default to the user `user1`. The API responses include this `owner` field.
 

--- a/context-hub/src/events.rs
+++ b/context-hub/src/events.rs
@@ -1,0 +1,34 @@
+use serde::Serialize;
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+#[derive(Clone, Serialize)]
+#[serde(tag = "type")]
+pub enum Event {
+    Created { id: Uuid },
+    Updated { id: Uuid },
+    Deleted { id: Uuid },
+    Moved { id: Uuid, new_parent: Uuid },
+    Shared { id: Uuid, principal: String },
+    Unshared { id: Uuid, principal: String },
+}
+
+#[derive(Clone)]
+pub struct EventBus {
+    tx: broadcast::Sender<Event>,
+}
+
+impl EventBus {
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(100);
+        Self { tx }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<Event> {
+        self.tx.subscribe()
+    }
+
+    pub fn send(&self, event: Event) {
+        let _ = self.tx.send(event);
+    }
+}

--- a/context-hub/src/lib.rs
+++ b/context-hub/src/lib.rs
@@ -3,3 +3,4 @@ pub mod search;
 pub mod snapshot;
 pub mod storage;
 pub mod indexer;
+pub mod events;

--- a/context-hub/src/main.rs
+++ b/context-hub/src/main.rs
@@ -12,6 +12,7 @@ mod search;
 mod snapshot;
 mod storage;
 mod indexer;
+mod events;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -25,7 +26,8 @@ async fn main() -> anyhow::Result<()> {
         search.index_all(&store_guard)?;
     }
     let indexer = Arc::new(indexer::LiveIndex::new(search.clone(), store.clone()));
-    let router = api::router(store.clone(), PathBuf::from("snapshots"), indexer.clone());
+    let events = events::EventBus::new();
+    let router = api::router(store.clone(), PathBuf::from("snapshots"), indexer.clone(), events.clone());
     // spawn periodic snapshots every hour on a LocalSet so non-Send types work
     let local = LocalSet::new();
     local.spawn_local(snapshot::snapshot_task(

--- a/context-hub/tests/server.rs
+++ b/context-hub/tests/server.rs
@@ -15,7 +15,8 @@ async fn server_health_endpoint() {
     std::fs::create_dir_all(&index_dir).unwrap();
     let search = Arc::new(search::SearchIndex::new(&index_dir).unwrap());
     let indexer = Arc::new(indexer::LiveIndex::new(search.clone(), store.clone()));
-    let router = api::router(store.clone(), tempdir.path().into(), indexer);
+    let events = context_hub::events::EventBus::new();
+    let router = api::router(store.clone(), tempdir.path().into(), indexer, events);
     let app = Router::new()
         .merge(router)
         .route("/health", get(|| async { "OK" }));
@@ -43,7 +44,8 @@ async fn root_created_on_use() {
     std::fs::create_dir_all(&index_dir).unwrap();
     let search = Arc::new(search::SearchIndex::new(&index_dir).unwrap());
     let indexer = Arc::new(indexer::LiveIndex::new(search.clone(), store.clone()));
-    let app = Router::new().merge(api::router(store.clone(), tempdir.path().into(), indexer));
+    let events = context_hub::events::EventBus::new();
+    let app = Router::new().merge(api::router(store.clone(), tempdir.path().into(), indexer, events));
 
     let req = axum::http::Request::builder()
         .method("POST")
@@ -74,7 +76,8 @@ async fn search_endpoint() {
     std::fs::create_dir_all(&index_dir).unwrap();
     let search = Arc::new(search::SearchIndex::new(&index_dir).unwrap());
     let indexer = Arc::new(indexer::LiveIndex::new(search.clone(), store.clone()));
-    let app = Router::new().merge(api::router(store.clone(), tempdir.path().into(), indexer.clone()));
+    let events = context_hub::events::EventBus::new();
+    let app = Router::new().merge(api::router(store.clone(), tempdir.path().into(), indexer.clone(), events));
 
     let req = axum::http::Request::builder()
         .method("POST")
@@ -115,7 +118,8 @@ async fn rename_endpoint() {
     std::fs::create_dir_all(&index_dir).unwrap();
     let search = Arc::new(search::SearchIndex::new(&index_dir).unwrap());
     let indexer = Arc::new(indexer::LiveIndex::new(search.clone(), store.clone()));
-    let app = Router::new().merge(api::router(store.clone(), tempdir.path().into(), indexer.clone()));
+    let events = context_hub::events::EventBus::new();
+    let app = Router::new().merge(api::router(store.clone(), tempdir.path().into(), indexer.clone(), events));
 
     let req = axum::http::Request::builder()
         .method("POST")
@@ -171,7 +175,8 @@ async fn move_endpoint() {
     std::fs::create_dir_all(&index_dir).unwrap();
     let search = Arc::new(search::SearchIndex::new(&index_dir).unwrap());
     let indexer = Arc::new(indexer::LiveIndex::new(search.clone(), store.clone()));
-    let app = Router::new().merge(api::router(store.clone(), tempdir.path().into(), indexer.clone()));
+    let events = context_hub::events::EventBus::new();
+    let app = Router::new().merge(api::router(store.clone(), tempdir.path().into(), indexer.clone(), events));
 
     let root = {
         let mut s = store.lock().await;

--- a/context-hub/tests/snapshot.rs
+++ b/context-hub/tests/snapshot.rs
@@ -91,7 +91,8 @@ async fn snapshot_endpoint_triggers_commit() {
     std::fs::create_dir_all(&index_dir).unwrap();
     let search = Arc::new(search::SearchIndex::new(&index_dir).unwrap());
     let indexer = Arc::new(indexer::LiveIndex::new(search.clone(), store.clone()));
-    let app = context_hub::api::router(store.clone(), repo_dir.clone(), indexer);
+    let events = context_hub::events::EventBus::new();
+    let app = context_hub::api::router(store.clone(), repo_dir.clone(), indexer, events);
 
     let req = axum::http::Request::builder()
         .method("POST")


### PR DESCRIPTION
## Summary
- implement `EventBus` for publishing document events
- expose `/ws` endpoint streaming events via SSE
- emit events on create, update, move, delete and share operations
- update server setup and tests for new router signature
- document the new endpoint

## Testing
- `pip install -r requirements-worker.txt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6849d0ac1acc832ea5f23040e944d410