### PR TITLE
Implement pointer resolver framework

### DIFF
--- a/context-hub/src/lib.rs
+++ b/context-hub/src/lib.rs
@@ -4,3 +4,4 @@ pub mod snapshot;
 pub mod storage;
 pub mod indexer;
 pub mod events;
+pub mod pointer;

--- a/context-hub/src/main.rs
+++ b/context-hub/src/main.rs
@@ -13,6 +13,7 @@ mod snapshot;
 mod storage;
 mod indexer;
 mod events;
+mod pointer;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/context-hub/src/pointer.rs
+++ b/context-hub/src/pointer.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use anyhow::{anyhow, Result};
+
+use crate::storage::crdt::Pointer;
+
+/// Trait for resolving and storing pointer targets.
+pub trait PointerResolver: Send + Sync {
+    /// Store data for the given pointer.
+    fn store(&self, pointer: &Pointer, data: &[u8]) -> Result<()>;
+    /// Fetch the data referenced by the given pointer.
+    fn fetch(&self, pointer: &Pointer) -> Result<Vec<u8>>;
+}
+
+/// Simple in-memory resolver used for testing.
+pub struct InMemoryResolver {
+    data: Mutex<HashMap<String, Vec<u8>>>,
+}
+
+impl InMemoryResolver {
+    pub fn new() -> Self {
+        Self {
+            data: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl PointerResolver for InMemoryResolver {
+    fn store(&self, pointer: &Pointer, data: &[u8]) -> Result<()> {
+        let mut map = self.data.lock().unwrap();
+        map.insert(pointer.target.clone(), data.to_vec());
+        Ok(())
+    }
+
+    fn fetch(&self, pointer: &Pointer) -> Result<Vec<u8>> {
+        let map = self.data.lock().unwrap();
+        map.get(&pointer.target)
+            .cloned()
+            .ok_or_else(|| anyhow!("pointer not found"))
+    }
+}
+
+/// Registry mapping pointer types to concrete resolvers.
+#[derive(Default)]
+pub struct ResolverRegistry {
+    resolvers: HashMap<String, Arc<dyn PointerResolver>>,
+}
+
+impl ResolverRegistry {
+    pub fn new() -> Self {
+        Self {
+            resolvers: HashMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, kind: impl Into<String>, resolver: Arc<dyn PointerResolver>) {
+        self.resolvers.insert(kind.into(), resolver);
+    }
+
+    pub fn get(&self, kind: &str) -> Option<&Arc<dyn PointerResolver>> {
+        self.resolvers.get(kind)
+    }
+}

--- a/context-hub/tests/pointer.rs
+++ b/context-hub/tests/pointer.rs
@@ -1,0 +1,33 @@
+use context_hub::{storage::crdt::{DocumentStore, DocumentType, Pointer}, pointer::{InMemoryResolver, PointerResolver}};
+use std::sync::Arc;
+
+#[test]
+fn resolve_pointer_with_memory_resolver() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let mut store = DocumentStore::new(tempdir.path()).unwrap();
+    let resolver = Arc::new(InMemoryResolver::new());
+    store.register_resolver("blob", resolver.clone());
+
+    let doc_id = store
+        .create(
+            "file.txt".to_string(),
+            "hello",
+            "user1".to_string(),
+            None,
+            DocumentType::Text,
+        )
+        .unwrap();
+
+    let ptr = Pointer {
+        pointer_type: "blob".to_string(),
+        target: "123".to_string(),
+        name: Some("data.bin".to_string()),
+        preview_text: None,
+    };
+    resolver.store(&ptr, b"payload").unwrap();
+
+    store.insert_pointer(doc_id, 1, ptr).unwrap();
+
+    let data = store.resolve_pointer(doc_id, 1).unwrap();
+    assert_eq!(data, b"payload".to_vec());
+}


### PR DESCRIPTION
## Summary
- add `pointer` module with trait and in-memory resolver
- support pointer insertion and resolution in the CRDT store
- expose pointer module from library and binary
- provide tests for pointer resolution

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6849d396acd4832e9523adf83b11e22d