### PR TITLE
Implement git pointer resolution

### DIFF
--- a/context-hub/README.md
+++ b/context-hub/README.md
@@ -24,6 +24,9 @@ The server exposes the following endpoints:
 - `GET /search?q=term` – search documents using a keyword query. Returns only
   results the caller has permission to read.
 - `GET /ws` – subscribe to a server-sent events stream of document changes.
+- `POST /docs/{id}/content?name=FILE` – attach a binary blob to a document.
+- `GET /docs/{id}/content/{idx}` – download an attached blob.
+- `GET /docs/{id}/resolve_pointer?name=FILE` – resolve a named pointer such as a git reference.
 
 Documents are stored as Automerge CRDTs and persisted as binary files under the `data` directory. Each document carries an **owner**. When a document is created, the `X-User-Id` header value is recorded as its owner. Existing files loaded from disk default to the user `user1`. The API responses include this `owner` field.
 

--- a/context-hub/src/pointer.rs
+++ b/context-hub/src/pointer.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, Result};
+use git2::{ObjectType, Repository};
+use serde::Deserialize;
 
 use crate::storage::crdt::Pointer;
 
@@ -65,6 +67,64 @@ impl PointerResolver for BlobPointerResolver {
     fn fetch(&self, pointer: &Pointer) -> Result<Vec<u8>> {
         let path = self.dir.join(&pointer.target);
         Ok(std::fs::read(path)?)
+    }
+}
+
+/// Target information for a Git pointer.
+#[derive(Deserialize)]
+struct GitTarget {
+    repo: String,
+    path: String,
+    #[serde(default)]
+    rev: Option<String>,
+}
+
+/// Resolver fetching files from a Git repository.
+pub struct GitPointerResolver {
+    cache: std::path::PathBuf,
+}
+
+impl GitPointerResolver {
+    /// Create a resolver caching clones under the given directory.
+    pub fn new(dir: impl Into<std::path::PathBuf>) -> Result<Self> {
+        let dir = dir.into();
+        std::fs::create_dir_all(&dir)?;
+        Ok(Self { cache: dir })
+    }
+
+    fn repo_path(&self, url: &str) -> std::path::PathBuf {
+        let sanitized: String = url
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+            .collect();
+        self.cache.join(sanitized)
+    }
+}
+
+impl PointerResolver for GitPointerResolver {
+    fn store(&self, _pointer: &Pointer, _data: &[u8]) -> Result<()> {
+        Err(anyhow!("git pointers are read-only"))
+    }
+
+    fn fetch(&self, pointer: &Pointer) -> Result<Vec<u8>> {
+        let target: GitTarget = serde_json::from_str(&pointer.target)?;
+        let repo_dir = self.repo_path(&target.repo);
+        let repo = if repo_dir.exists() {
+            Repository::open(&repo_dir)?
+        } else {
+            Repository::clone(&target.repo, &repo_dir)?
+        };
+
+        let rev = target.rev.as_deref().unwrap_or("HEAD");
+        let obj = repo.revparse_single(rev)?;
+        let commit = obj.peel_to_commit()?;
+        let tree = commit.tree()?;
+        let entry = tree.get_path(std::path::Path::new(&target.path))?;
+        if entry.kind() != Some(ObjectType::Blob) {
+            return Err(anyhow!("target is not a file"));
+        }
+        let blob = repo.find_blob(entry.id())?;
+        Ok(blob.content().to_vec())
     }
 }
 

--- a/context-hub/tests/pointer.rs
+++ b/context-hub/tests/pointer.rs
@@ -1,8 +1,9 @@
 use context_hub::{
-    pointer::{InMemoryResolver, PointerResolver},
+    pointer::{GitPointerResolver, InMemoryResolver, PointerResolver},
     storage::crdt::{DocumentStore, DocumentType, Pointer},
 };
 use std::sync::Arc;
+use git2::Repository;
 
 #[test]
 fn resolve_pointer_with_memory_resolver() {
@@ -33,4 +34,59 @@ fn resolve_pointer_with_memory_resolver() {
 
     let data = store.resolve_pointer(doc_id, 1).unwrap();
     assert_eq!(data, b"payload".to_vec());
+}
+
+#[test]
+fn resolve_git_pointer() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let repo_dir = tempdir.path().join("repo");
+    std::fs::create_dir_all(&repo_dir).unwrap();
+    let repo = Repository::init(&repo_dir).unwrap();
+    std::fs::write(repo_dir.join("file.txt"), b"hello git").unwrap();
+    {
+        let mut index = repo.index().unwrap();
+        index.add_path(std::path::Path::new("file.txt")).unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let sig = repo.signature().unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap();
+    }
+
+    let mut store = DocumentStore::new(tempdir.path().join("data")).unwrap();
+    let resolver = Arc::new(GitPointerResolver::new(tempdir.path().join("cache")).unwrap());
+    store.register_resolver("git", resolver);
+
+    let doc_id = store
+        .create(
+            "code".to_string(),
+            "",
+            "user1".to_string(),
+            None,
+            DocumentType::Text,
+        )
+        .unwrap();
+
+    let head = repo.head().unwrap().target().unwrap();
+    let target = serde_json::json!({
+        "repo": repo_dir.to_str().unwrap(),
+        "path": "file.txt",
+        "rev": head.to_string(),
+    })
+    .to_string();
+
+    let ptr = Pointer {
+        pointer_type: "git".to_string(),
+        target,
+        name: Some("file.txt".to_string()),
+        preview_text: None,
+    };
+
+    store.insert_pointer(doc_id, 0, ptr).unwrap();
+
+    let data = store.resolve_pointer(doc_id, 0).unwrap();
+    assert_eq!(data, b"hello git".to_vec());
+
+    let data2 = store.resolve_pointer_by_name(doc_id, "file.txt").unwrap();
+    assert_eq!(data2, b"hello git".to_vec());
 }


### PR DESCRIPTION
## Summary
- add `GitPointerResolver` for fetching files from repositories
- support resolving pointers by name through a new `/docs/{id}/resolve_pointer` endpoint
- expose blob and pointer routes in the Context Hub README
- update document store to look up pointers by name
- test git pointer resolver functionality

## Testing
- `pip install -r requirements-worker.txt`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684a417cb164832e9395c1e1a22cc209