### PR TITLE
Add JWT auth and agent scope API

### DIFF
--- a/context-hub/Cargo.lock
+++ b/context-hub/Cargo.lock
@@ -341,10 +341,12 @@ name = "context-hub"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "chrono",
  "futures",
  "git2",
+ "jsonwebtoken",
  "loro",
  "reqwest",
  "serde",
@@ -1098,6 +1100,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,6 +1373,21 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1932,6 +1963,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2235,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2203,6 +2245,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2211,12 +2254,28 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2264,12 +2323,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2304,6 +2385,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -2446,6 +2537,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.12",
+ "time",
 ]
 
 [[package]]
@@ -2813,6 +2916,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2985,6 +3098,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3147,6 +3266,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"

--- a/context-hub/Cargo.toml
+++ b/context-hub/Cargo.toml
@@ -16,6 +16,9 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 tantivy = { version = "0.19", default-features = false, features = ["lz4-compression", "mmap"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 futures = "0.3"
+jsonwebtoken = "9"
+async-trait = "0.1"
+reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/context-hub/README.md
+++ b/context-hub/README.md
@@ -12,6 +12,12 @@ All API calls require an `X-User-Id` HTTP header identifying the current user.
 An optional `X-Agent-Id` header can be supplied when the request originates from
 an agent acting on behalf of the user.
 
+Alternatively clients may authenticate with a bearer token using the
+`Authorization` header. Tokens are verified with either a shared secret
+(`JWT_SECRET`) or against an Azure Entra ID JWKS endpoint specified by
+`AZURE_JWKS_URL`. The token must contain a `sub` claim with the user ID and may
+include an `agent` claim naming the acting agent.
+
 The server exposes the following endpoints:
 
 - `GET /health` – simple health check returning `OK`.
@@ -48,3 +54,16 @@ to a list of allowed folder UUIDs:
 When a request includes `X-Agent-Id`, the configured scope is checked first. If
 the target document lies outside the allowed folders, access is denied even if
 the user would normally have permission.
+
+Agent scopes can now be managed via the API:
+
+```
+POST /agents/{agentId}/scopes   # body: {"folders": ["<folder-uuid>"]}
+DELETE /agents/{agentId}/scopes # remove any scope restrictions
+```
+
+You can also list sharing information on a document or folder with:
+
+```
+GET /docs/{id}/sharing
+```

--- a/context-hub/src/auth.rs
+++ b/context-hub/src/auth.rs
@@ -1,0 +1,95 @@
+use async_trait::async_trait;
+use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct Claims {
+    pub sub: String,
+    #[serde(default)]
+    pub agent: Option<String>,
+}
+
+#[async_trait]
+pub trait TokenVerifier: Send + Sync {
+    async fn verify(&self, token: &str) -> Option<Claims>;
+}
+
+pub struct Hs256Verifier {
+    key: DecodingKey,
+}
+
+impl Hs256Verifier {
+    pub fn new(secret: String) -> Self {
+        Self {
+            key: DecodingKey::from_secret(secret.as_bytes()),
+        }
+    }
+}
+
+#[async_trait]
+impl TokenVerifier for Hs256Verifier {
+    async fn verify(&self, token: &str) -> Option<Claims> {
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.validate_exp = false;
+        decode::<Claims>(token, &self.key, &validation)
+            .ok()
+            .map(|d| d.claims)
+    }
+}
+
+pub struct AzureEntraIdVerifier {
+    jwks_url: String,
+    client: reqwest::Client,
+    keys: Mutex<Option<Jwks>>,
+}
+
+#[derive(Deserialize)]
+struct Jwks {
+    keys: Vec<Jwk>,
+}
+
+#[derive(Deserialize)]
+struct Jwk {
+    kid: String,
+    n: String,
+    e: String,
+}
+
+impl AzureEntraIdVerifier {
+    pub fn new(jwks_url: String) -> Self {
+        Self {
+            jwks_url,
+            client: reqwest::Client::new(),
+            keys: Mutex::new(None),
+        }
+    }
+
+    async fn fetch_keys(&self) -> reqwest::Result<Jwks> {
+        self.client.get(&self.jwks_url).send().await?.json().await
+    }
+}
+
+#[async_trait]
+impl TokenVerifier for AzureEntraIdVerifier {
+    async fn verify(&self, token: &str) -> Option<Claims> {
+        let header = decode_header(token).ok()?;
+        let kid = header.kid?;
+        let mut guard = self.keys.lock().await;
+        if guard.is_none() {
+            if let Ok(jwks) = self.fetch_keys().await {
+                *guard = Some(jwks);
+            } else {
+                return None;
+            }
+        }
+        let jwks = guard.as_ref()?;
+        let jwk = jwks.keys.iter().find(|k| k.kid == kid)?;
+        let key = DecodingKey::from_rsa_components(&jwk.n, &jwk.e).ok()?;
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.validate_exp = false;
+        decode::<Claims>(token, &key, &validation)
+            .ok()
+            .map(|d| d.claims)
+    }
+}

--- a/context-hub/src/lib.rs
+++ b/context-hub/src/lib.rs
@@ -5,3 +5,4 @@ pub mod pointer;
 pub mod search;
 pub mod snapshot;
 pub mod storage;
+pub mod auth;

--- a/context-hub/tests/pointer.rs
+++ b/context-hub/tests/pointer.rs
@@ -2,8 +2,8 @@ use context_hub::{
     pointer::{GitPointerResolver, InMemoryResolver, PointerResolver},
     storage::crdt::{DocumentStore, DocumentType, Pointer},
 };
-use std::sync::Arc;
 use git2::Repository;
+use std::sync::Arc;
 
 #[test]
 fn resolve_pointer_with_memory_resolver() {
@@ -50,7 +50,8 @@ fn resolve_git_pointer() {
         let tree_id = index.write_tree().unwrap();
         let tree = repo.find_tree(tree_id).unwrap();
         let sig = repo.signature().unwrap();
-        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
     }
 
     let mut store = DocumentStore::new(tempdir.path().join("data")).unwrap();

--- a/context-hub/tests/snapshot.rs
+++ b/context-hub/tests/snapshot.rs
@@ -3,6 +3,7 @@ use context_hub::{
     snapshot::SnapshotManager,
     storage::crdt::{DocumentStore, DocumentType},
 };
+use context_hub::auth::Hs256Verifier;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::task::LocalSet;
@@ -96,7 +97,14 @@ async fn snapshot_endpoint_triggers_commit() {
     let search = Arc::new(search::SearchIndex::new(&index_dir).unwrap());
     let indexer = Arc::new(indexer::LiveIndex::new(search.clone(), store.clone()));
     let events = context_hub::events::EventBus::new();
-    let app = context_hub::api::router(store.clone(), repo_dir.clone(), indexer, events);
+    let verifier = Arc::new(Hs256Verifier::new("secret".into()));
+    let app = context_hub::api::router(
+        store.clone(),
+        repo_dir.clone(),
+        indexer,
+        events,
+        verifier,
+    );
 
     let req = axum::http::Request::builder()
         .method("POST")


### PR DESCRIPTION
## Summary
- integrate jsonwebtoken authentication with optional `Authorization` header
- manage agent folder scopes via new API endpoints
- expose sharing info endpoint
- restrict event stream by permissions
- document new endpoints
- support Azure Entra ID verification through an abstract token verifier

## Testing
- `pip install -r requirements-worker.txt`
- `cargo test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a4439a7e8832e84c5b8793a620e3c