### PR TITLE
Add performance benchmark tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,3 +335,21 @@ The `agents/` directory contains agent implementations that the worker container
 invoke to process tasks. Each agent registers itself in `agents.AGENT_REGISTRY`
 and exposes a `run()` method used to handle the commands from a
 `WorkerTaskEvent`.
+
+## Tests
+
+Install the Python dependencies and run unit tests with `pytest`:
+
+```bash
+pip install -r requirements-worker.txt
+pytest
+```
+
+Performance benchmarks use the `pytest-benchmark` plugin. Generate a
+benchmark report for core functionality with:
+
+```bash
+pytest tests/test_performance.py --benchmark-only
+```
+
+The command prints a summary table of timing results to the console.

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -6,3 +6,4 @@ requests
 firecrawl-py>=1.0.0
 fastapi
 jinja2>=3.1.0
+pytest-benchmark

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,36 @@
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from events import Event, WorkerTaskEvent, utils
+
+sample_event = {
+    "timestamp": datetime.utcnow().isoformat(),
+    "source": "client",
+    "type": "llm.chat",
+    "userID": "u123",
+    "metadata": {
+        "messages": [{"role": "user", "content": "hello"}],
+        "commands": ["echo hi"],
+        "task": "say hi",
+    },
+}
+
+
+def test_event_from_dict_benchmark(benchmark):
+    benchmark(Event.from_dict, sample_event)
+
+
+def test_worker_task_from_dict_benchmark(benchmark):
+    benchmark(WorkerTaskEvent.from_dict, sample_event)
+
+
+def test_event_to_dict_benchmark(benchmark):
+    event = Event.from_dict(sample_event)
+    benchmark(event.to_dict)
+
+
+def test_event_matches_benchmark(benchmark):
+    benchmark(utils.event_matches, "foo.bar.baz", "foo.*")


### PR DESCRIPTION
## Summary
- add pytest-benchmark dependency
- provide performance benchmark tests for events
- document how to run unit tests and benchmarks

## Testing
- `pip install -r requirements-worker.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a93964f4c832ea49b35d83d11d41a