### PR TITLE
Add WebSocket channel for collaborative editing

### DIFF
--- a/context-hub/Cargo.toml
+++ b/context-hub/Cargo.toml
@@ -13,6 +13,7 @@ uuid = { version = "1", features = ["v4"] }
 anyhow = "1"
 tokio-stream = { version = "0.1", features = ["sync"] }
 futures = "0.3"
+bytes = "1"
 
 [dev-dependencies]
 git2 = "0.18"


### PR DESCRIPTION
## Summary
- extend `AppState` with document WebSocket channels
- expose `/ws/docs/{id}` endpoint
- handle WebSocket operations and broadcast updates to subscribers
- notify WebSocket clients when docs are changed via REST
- add bytes dependency for WebSocket binary messages

## Testing
- `cargo test --manifest-path context-hub/Cargo.toml --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684b1832ed60832eb800757e63ee5248