### PR TITLE
Add test jobs to CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,29 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install Python dependencies
+        run: pip install -r requirements-worker.txt
+      - name: Run Python tests
+        run: pytest -q
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run Context Hub tests
+        run: cargo test --workspace --locked
+
   setup-infrastructure:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/context-hub/Cargo.toml
+++ b/context-hub/Cargo.toml
@@ -24,8 +24,8 @@ tower = "0.5"
 futures-util = "0.3"
 bytes = "1"
 criterion = "0.5"
+tokio-tungstenite = "0.26"
 
 [[bench]]
 name = "search_bench"
 harness = false
-tokio-tungstenite = "0.26"

--- a/context-hub/tests/pointer.rs
+++ b/context-hub/tests/pointer.rs
@@ -49,7 +49,8 @@ fn resolve_git_pointer() {
         index.write().unwrap();
         let tree_id = index.write_tree().unwrap();
         let tree = repo.find_tree(tree_id).unwrap();
-        let sig = repo.signature().unwrap();
+        // Use a synthetic signature rather than relying on the user's git config
+        let sig = git2::Signature::now("tester", "tester@example.com").unwrap();
         repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
             .unwrap();
     }

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -6,4 +6,5 @@ requests
 firecrawl-py>=1.0.0
 fastapi
 jinja2>=3.1.0
+PyJWT>=2.8.0
 pytest-benchmark


### PR DESCRIPTION
## Summary
- run CI tests for Python and Rust
- gate deployment on tests
- fix missing dev dependency in context-hub

## Testing
- `pytest -q`
- `cargo test --workspace --locked`


------
https://chatgpt.com/codex/tasks/task_e_684bbc6b74c8832eb314c6082a0bf739