### PR TITLE
Add snapshot history API

### DIFF
--- a/context-hub/README.md
+++ b/context-hub/README.md
@@ -16,6 +16,8 @@ The server can be configured through environment variables:
 | `PORT` | port to bind | `3000` |
 | `DATA_DIR` | directory for live documents | `data` |
 | `SNAPSHOT_DIR` | directory for snapshots | `snapshots` |
+| `SNAPSHOT_INTERVAL_SECS` | snapshot period in seconds | `3600` |
+| `SNAPSHOT_RETENTION` | number of snapshot tags to keep | *(unset)* |
 | `INDEX_DIR` | directory for search index | `index` |
 | `BLOB_DIR` | directory for blob storage | `blobs` |
 | `JWT_SECRET` | HS256 secret when not using Azure AD | `secret` |
@@ -68,6 +70,8 @@ include an `agent` claim naming the acting agent.
 - `DELETE /agents/{agentId}/scopes` – remove scope restrictions.
 - `POST /snapshot` – force an immediate snapshot of all documents.
 - `POST /restore` – restore from the latest snapshot.
+- `GET /snapshots` – list recent snapshot commit IDs and timestamps.
+- `GET /snapshots/{rev}/docs/{id}` – fetch a document at a given snapshot.
 - `GET /health` – basic health check.
 
 Documents are stored as Automerge CRDTs and persisted as binary files under the `DATA_DIR` directory. Each document carries an **owner**. When a document is created, the `X-User-Id` header value is recorded as its owner. Existing files loaded from disk default to the user `user1`. The API responses include this `owner` field.
@@ -150,4 +154,10 @@ GET /docs/{id}/sharing
    ```bash
    curl -X POST -H "X-User-Id: user1" http://localhost:3000/snapshot
    curl -X POST -H "X-User-Id: user1" http://localhost:3000/restore
+   ```
+
+   List snapshots:
+
+   ```bash
+   curl -H "X-User-Id: user1" http://localhost:3000/snapshots
    ```

--- a/context-hub/tests/realtime.rs
+++ b/context-hub/tests/realtime.rs
@@ -42,6 +42,7 @@ async fn realtime_updates_stream() {
     let router = api::router(
         store.clone(),
         tempdir.path().into(),
+        None,
         indexer,
         events.clone(),
         verifier,

--- a/context-hub/tests/server.rs
+++ b/context-hub/tests/server.rs
@@ -23,6 +23,7 @@ async fn server_health_endpoint() {
     let router = api::router(
         store.clone(),
         tempdir.path().into(),
+        None,
         indexer,
         events,
         verifier,
@@ -61,6 +62,7 @@ async fn root_created_on_use() {
     let app = Router::new().merge(api::router(
         store.clone(),
         tempdir.path().into(),
+        None,
         indexer,
         events,
         verifier,
@@ -102,6 +104,7 @@ async fn search_endpoint() {
     let app = Router::new().merge(api::router(
         store.clone(),
         tempdir.path().into(),
+        None,
         indexer.clone(),
         events,
         verifier,
@@ -155,6 +158,7 @@ async fn rename_endpoint() {
     let app = Router::new().merge(api::router(
         store.clone(),
         tempdir.path().into(),
+        None,
         indexer.clone(),
         events,
         verifier,
@@ -225,6 +229,7 @@ async fn move_endpoint() {
     let app = Router::new().merge(api::router(
         store.clone(),
         tempdir.path().into(),
+        None,
         indexer.clone(),
         events,
         verifier,
@@ -374,6 +379,7 @@ async fn blob_attach_and_fetch() {
     let app = Router::new().merge(api::router(
         store.clone(),
         tempdir.path().into(),
+        None,
         indexer.clone(),
         events,
         verifier,
@@ -438,6 +444,7 @@ async fn agent_scope_api() {
     let app = Router::new().merge(api::router(
         store.clone(),
         tempdir.path().into(),
+        None,
         indexer.clone(),
         events,
         verifier,

--- a/context-hub/tests/snapshot.rs
+++ b/context-hub/tests/snapshot.rs
@@ -66,6 +66,7 @@ async fn snapshot_task_runs() {
         store.clone(),
         mgr.clone(),
         Duration::from_millis(100),
+        None,
     ));
     local
         .run_until(tokio::time::sleep(Duration::from_millis(150)))
@@ -102,6 +103,7 @@ async fn snapshot_endpoint_triggers_commit() {
     let app = context_hub::api::router(
         store.clone(),
         repo_dir.clone(),
+        None,
         indexer,
         events,
         verifier,
@@ -189,4 +191,132 @@ fn restore_by_timestamp() {
 
     mgr.restore(&mut store, &ts).unwrap();
     assert_eq!(store.get(doc).unwrap().text(), "v1");
+}
+
+#[tokio::test]
+async fn snapshot_listing_endpoint() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let repo_dir = tempdir.path().join("repo");
+    let data_dir = tempdir.path().join("data");
+    let store = Arc::new(RwLock::new(DocumentStore::new(&data_dir).unwrap()));
+    let index_dir = repo_dir.join("index");
+    std::fs::create_dir_all(&index_dir).unwrap();
+    let search = Arc::new(search::SearchIndex::new(&index_dir).unwrap());
+    let indexer = Arc::new(indexer::LiveIndex::new(search.clone(), store.clone()));
+    let events = context_hub::events::EventBus::new();
+    let verifier = Arc::new(Hs256Verifier::new("secret".into()));
+    let app = context_hub::api::router(
+        store.clone(),
+        repo_dir.clone(),
+        None,
+        indexer,
+        events,
+        verifier,
+    );
+
+    {
+        let mut s = store.write().await;
+        s.create(
+            "a.txt".to_string(),
+            "hi",
+            "user1".to_string(),
+            None,
+            DocumentType::Text,
+        )
+        .unwrap();
+    }
+
+    let req = axum::http::Request::builder()
+        .method("POST")
+        .uri("/snapshot")
+        .header("X-User-Id", "user1")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let _ = app.clone().oneshot(req).await.unwrap();
+
+    let req = axum::http::Request::builder()
+        .uri("/snapshots")
+        .header("X-User-Id", "user1")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let arr: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+    assert!(!arr.is_empty());
+}
+
+#[tokio::test]
+async fn snapshot_fetch_doc_endpoint() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let repo_dir = tempdir.path().join("repo");
+    let data_dir = tempdir.path().join("data");
+    let store = Arc::new(RwLock::new(DocumentStore::new(&data_dir).unwrap()));
+    let index_dir = repo_dir.join("index");
+    std::fs::create_dir_all(&index_dir).unwrap();
+    let search = Arc::new(search::SearchIndex::new(&index_dir).unwrap());
+    let indexer = Arc::new(indexer::LiveIndex::new(search.clone(), store.clone()));
+    let events = context_hub::events::EventBus::new();
+    let verifier = Arc::new(Hs256Verifier::new("secret".into()));
+    let app = context_hub::api::router(
+        store.clone(),
+        repo_dir.clone(),
+        None,
+        indexer,
+        events,
+        verifier,
+    );
+
+    let doc_id = {
+        let mut s = store.write().await;
+        s.create(
+            "a.txt".to_string(),
+            "v1",
+            "user1".to_string(),
+            None,
+            DocumentType::Text,
+        )
+        .unwrap()
+    };
+
+    let req = axum::http::Request::builder()
+        .method("POST")
+        .uri("/snapshot")
+        .header("X-User-Id", "user1")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let _ = app.clone().oneshot(req).await.unwrap();
+
+    {
+        let mut s = store.write().await;
+        s.update(doc_id, "v2").unwrap();
+    }
+    let req = axum::http::Request::builder()
+        .method("POST")
+        .uri("/snapshot")
+        .header("X-User-Id", "user1")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let _ = app.clone().oneshot(req).await.unwrap();
+
+    let req = axum::http::Request::builder()
+        .uri("/snapshots")
+        .header("X-User-Id", "user1")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let arr: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+    let rev = arr.first().unwrap()["id"].as_str().unwrap();
+
+    let req = axum::http::Request::builder()
+        .uri(format!("/snapshots/{}/docs/{}", rev, doc_id))
+        .header("X-User-Id", "user1")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(val["content"].as_str().unwrap(), "v2");
 }

--- a/context-hub/tests/websocket.rs
+++ b/context-hub/tests/websocket.rs
@@ -22,6 +22,7 @@ async fn doc_websocket_broadcasts_updates() {
     let router = api::router(
         store.clone(),
         tempdir.path().into(),
+        None,
         indexer,
         events,
         verifier,


### PR DESCRIPTION
## Summary
- expose snapshot history via new `/snapshots` endpoint
- allow fetching document contents for a specific revision
- make snapshot interval and retention configurable
- tag snapshots in git and prune old tags
- update tests and docs for new behavior

## Testing
- `cargo check -p context-hub`
- `cargo test -p context-hub`

------
https://chatgpt.com/codex/tasks/task_e_684bfd9d6e70832e8f85fff0fd5a46b4