### PR TITLE
Fix search index directory creation

### DIFF
--- a/context-hub/README.md
+++ b/context-hub/README.md
@@ -23,6 +23,9 @@ The server can be configured through environment variables:
 | `JWT_SECRET` | HS256 secret when not using Azure AD | `secret` |
 | `AZURE_JWKS_URL` | JWKS endpoint for Azure tokens | *(unset)* |
 
+The data, snapshot, index, and blob directories are created automatically if
+they do not already exist.
+
 All API calls require an `X-User-Id` HTTP header identifying the current user.
 An optional `X-Agent-Id` header can be supplied when the request originates from
 an agent acting on behalf of the user.

--- a/context-hub/context-hub-core/src/search.rs
+++ b/context-hub/context-hub-core/src/search.rs
@@ -25,6 +25,8 @@ impl SearchIndex {
         let content = schema_builder.add_text_field("content", TEXT);
         let folder = schema_builder.add_text_field("folder", TEXT);
         let schema = schema_builder.build();
+        let path = path.as_ref();
+        std::fs::create_dir_all(path)?;
         let dir = MmapDirectory::open(path)?;
         let index = Index::open_or_create(dir, schema.clone())?;
         Ok(Self {


### PR DESCRIPTION
## Summary
- create the search index directory if it doesn't exist
- mention automatic directory creation in README

## Testing
- `cargo test -p context-hub -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_684c06bcebb8832e9421a7b6b98b5731