### PR TITLE
Grant secret deletion permissions

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -98,7 +98,7 @@ vault = keyvault.Vault(
 authorization.RoleAssignment(
     "kv-admin",
     principal_id = client_cfg.object_id,                  # who is running Pulumi
-    principal_type = "ServicePrincipal",          
+    principal_type = "ServicePrincipal",
     role_definition_id = (
         "/subscriptions/" + subscription_id +
         "/providers/Microsoft.Authorization/roleDefinitions/" +
@@ -108,6 +108,20 @@ authorization.RoleAssignment(
     role_assignment_name = str(uuid.uuid5(
         uuid.NAMESPACE_URL, f"{rg.name}-kv-admin-{client_cfg.object_id}"
     )),
+)
+
+# Allow the Pulumi service principal to manage Key Vault secrets
+kv_secret_delete_guid = str(uuid.uuid5(uuid.NAMESPACE_DNS, f"{stack_suffix}-kv-secret-delete"))
+authorization.RoleAssignment(
+    "pulumi-sp-secret-delete",
+    principal_id=client_cfg.object_id,
+    principal_type="ServicePrincipal",
+    role_definition_id=pulumi.Output.concat(
+        "/subscriptions/", subscription_id,
+        "/providers/Microsoft.Authorization/roleDefinitions/b86a8fe4-44ce-4948-aee5-eccb2c155cd7",
+    ),
+    scope=vault.id,
+    role_assignment_name=kv_secret_delete_guid,
 )
 
 


### PR DESCRIPTION
## Summary
- assign `pulumi-sp-secret-delete` Key Vault Secrets Officer role
- use the pulumi service principal's object id automatically

## Testing
- `pip install -r requirements-worker.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c0649ce58832eb1637eefea51babf