### PR TITLE
Fix POSTGRES_PASSWORD environment variable

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -494,7 +494,7 @@ postgres_cg = aci_group(
     5432,
     [
         containerinstance.EnvironmentVariableArgs(name="POSTGRES_USER", value=postgres_user),
-        containerinstance.EnvironmentVariableArgs(name="POSTGRES_PASSWORD", secure_value=postgres_password),
+        containerinstance.EnvironmentVariableArgs(name="POSTGRES_PASSWORD", value=postgres_password),
         containerinstance.EnvironmentVariableArgs(name="POSTGRES_DB", value=postgres_db),
     ],
     volumes=[


### PR DESCRIPTION
## Summary
- mark `POSTGRES_PASSWORD` as a normal environment variable using `value`

## Testing
- `pip install -r requirements-worker.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c482a2d50832e9367c89bb6707895