### PR TITLE
Add Context Hub container and ACI deployment

### DIFF
--- a/Dockerfile.contexthub
+++ b/Dockerfile.contexthub
@@ -1,0 +1,11 @@
+FROM rust:1.72-slim AS build
+WORKDIR /build
+COPY context-hub ./context-hub
+WORKDIR /build/context-hub
+RUN cargo build --release
+
+FROM debian:bullseye-slim
+COPY --from=build /build/context-hub/target/release/context-hub /usr/local/bin/context-hub
+WORKDIR /app
+EXPOSE 3000
+CMD ["context-hub"]

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -46,6 +46,7 @@ domain            = cfg.get("domain")   or "vextir.com"
 worker_image      = cfg.get("workerImage")  or "vextiracr.azurecr.io/worker-task:latest"
 voice_ws_image    = cfg.get("voiceWsImage") or "vextiracr.azurecr.io/voice-ws:latest"
 ui_image          = cfg.require("uiImage")
+hub_image         = cfg.get("hubImage") or "vextiracr.azurecr.io/context-hub:latest"
 
 openai_api_key    = cfg.require_secret("openaiApiKey")
 aad_client_id     = cfg.require_secret("aadClientId")
@@ -574,8 +575,16 @@ voice_cg = aci_group(
     public=True,
 )
 
+hub_cg = aci_group(
+    "contexthub",
+    hub_image,
+    3000,
+    [],
+)
+
 pulumi.export("uiFqdn", ui_cg.ip_address.apply(lambda ip: ip.fqdn))
 pulumi.export("voiceWsFqdn", voice_cg.ip_address.apply(lambda ip: ip.fqdn))
+pulumi.export("contextHubIp", hub_cg.ip_address.apply(lambda ip: ip.ip))
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 12. FUNCTION APP


### PR DESCRIPTION
## Summary
- containerize context-hub service
- deploy context hub in Pulumi using ACI
- make context hub container private for internal access

## Testing
- `pip install -r requirements-worker.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c59aa46c0832e8a756f45b0268380