### PR TITLE
Fix ACR login name in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Log in to Azure Container Registry
         run: |
           az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-          az acr login --name vextiracr
+          az acr login --name vextiracrdev
         env:
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}


### PR DESCRIPTION
## Summary
- correct the Azure Container Registry name during login in the deployment workflow

## Testing
- `pip install -r requirements-worker.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c6ff5de44832e888d907b5d6170b7