### PR TITLE
Fix ACI container group names

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -493,6 +493,7 @@ def aci_group(
         name,
         resource_group_name=rg.name,
         location=rg.location,
+        container_group_name=name,
         os_type="Linux",
         subnet_ids=subnet_ids,
         ip_address=ip_cfg,
@@ -524,7 +525,10 @@ def aci_group(
             )
         ),
         image_registry_credentials=registry_creds,
-        opts=pulumi.ResourceOptions(replace_on_changes=["containers"]),
+        opts=pulumi.ResourceOptions(
+            replace_on_changes=["containers"],
+            delete_before_replace=True,
+        ),
     )
 
 postgres_cg = aci_group(


### PR DESCRIPTION
## Summary
- keep container group names consistent by passing `container_group_name`
- delete container groups before replacement to free DNS labels

## Testing
- `pip install -r requirements-worker.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c73040048832e9e75e42716f1d1ec