### PR TITLE
Fix AFD origin host header

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -808,6 +808,7 @@ def origin_group(name: str, probe_path: str, host: pulumi.Input[str], port: int)
         origin_group_name=og.name,
         origin_name=f"{name}Origin",
         host_name=host,
+        origin_host_header=host,
         https_port=port,
         http_port=80 if port == 443 else port,
         enabled_state=cdn.EnabledState.ENABLED,


### PR DESCRIPTION
## Summary
- ensure AFD origin sends host header to backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c95c61178832e94e0a5f89fdc4118