### PR TITLE
Switch chat UI to HTTP

### DIFF
--- a/AUTH_SYSTEM_GUIDE.md
+++ b/AUTH_SYSTEM_GUIDE.md
@@ -7,7 +7,7 @@ The Vextir Chat UI container has been enhanced with a comprehensive authenticati
 ## Architecture
 
 -### Multi-Service Design
-- **Gateway** (Port 443): Routes `/auth` to the auth service and `/chat` to the chat interface
+- **Gateway** (Port 80): Routes `/auth` to the auth service and `/chat` to the chat interface
 - **Azure Functions**: Backend API for user management and authentication
 
 ### Authorization Flow
@@ -80,7 +80,7 @@ chmod +x start.sh
 
 # Docker deployment
 docker build -t vextir-chat .
-docker run -p 443:443 \
+docker run -p 80:80 \
   -e AUTH_API_URL="https://your-function-app.azurewebsites.net/api" \
   -e JWT_SIGNING_KEY="your-jwt-signing-key" \
   vextir-chat

--- a/chat_client/Dockerfile
+++ b/chat_client/Dockerfile
@@ -21,8 +21,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Make startup script executable
 RUN chmod +x ./start.sh
 
-# Expose HTTPS port for the gateway
-EXPOSE 443
+# Expose HTTP port for the gateway (TLS is terminated by Azure Front Door)
+EXPOSE 80
 
 # Run the multi-service startup script
 CMD ["./start.sh"]

--- a/chat_client/README.md
+++ b/chat_client/README.md
@@ -4,7 +4,7 @@ This directory contains the Vextir Chat client secured with Azure Entra ID.
 
 ## Architecture
 
-The chat client exposes a gateway service on port 443 that handles the OAuth
+The chat client exposes a gateway service on port 80 that handles the OAuth
 flow with Azure Entra ID and proxies the Chainlit interface.
 
 ## Features
@@ -83,7 +83,7 @@ docker build -t vextir-chat .
 
 ### Run
 ```bash
-docker run -p 443:443 \
+docker run -p 80:80 \
   -e AAD_CLIENT_ID="<app-id>" \
   -e AAD_TENANT_ID="<tenant-id>" \
   -e AAD_CLIENT_SECRET="<client-secret>" \
@@ -147,7 +147,7 @@ Make sure your Azure Function has the UserAuth function deployed and configured.
 
 1. **Services won't start**
    - Check environment variables are set
-   - Verify port 443 is available
+   - Verify port 80 is available
    - Check Python dependencies are installed
 
 2. **Authentication fails**
@@ -156,7 +156,7 @@ Make sure your Azure Function has the UserAuth function deployed and configured.
 
 3. **Chat not accessible**
    - Confirm authentication is working
-   - Check the gateway service is running on port 443
+   - Check the gateway service is running on port 80
    - Verify authentication middleware is working
 
 ### Logs

--- a/chat_client/start.sh
+++ b/chat_client/start.sh
@@ -16,6 +16,6 @@ check_env_var "AAD_CLIENT_ID"
 check_env_var "AAD_TENANT_ID"
 check_env_var "AAD_CLIENT_SECRET"
 
-# Run the gateway on HTTPS port 443
-exec python -m uvicorn gateway_app:app --host 0.0.0.0 --port 443
+# Run the gateway on HTTP port 80 (TLS handled by Azure Front Door)
+exec python -m uvicorn gateway_app:app --host 0.0.0.0 --port 80
 

--- a/chat_client/start_services.py
+++ b/chat_client/start_services.py
@@ -13,14 +13,14 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 
 def start_gateway():
-    """Run the combined gateway on port 443."""
-    print("🚀 Starting Gateway on port 443...")
+    """Run the combined gateway on port 80."""
+    print("🚀 Starting Gateway on port 80...")
     try:
         subprocess.run([
             sys.executable, "-m", "uvicorn",
             "gateway_app:app",
             "--host", "0.0.0.0",
-            "--port", "443"
+            "--port", "80"
         ], check=True)
     except subprocess.CalledProcessError as e:
         print(f"❌ Gateway failed to start: {e}")

--- a/deployment_test_guide.py
+++ b/deployment_test_guide.py
@@ -74,7 +74,7 @@ def get_azure_resources():
     print("1. Go to https://portal.azure.com")
     print("2. Navigate to Resource Group 'vextir'")
     print("3. Look for:")
-    print("   - Container Instance 'chat-ui' → Get public IP (Gateway on :443)")
+    print("   - Container Instance 'chat-ui' → Get public IP (Gateway on :80)")
     print("   - Function App 'vextir-func-*' → Get URL (API endpoints)")
     print("   - Container Registry 'vextiracr' → Container images")
     print("   - Cosmos DB 'vextir-cosmos-*' → User and event storage")

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -584,7 +584,7 @@ gitea_cg = aci_group(
 ui_cg = aci_group(
     "chatui",
     ui_image,
-    443,
+    80,
     [
         containerinstance.EnvironmentVariableArgs(name="API_BASE", value=pulumi.Output.concat("https://api.", domain)),
         containerinstance.EnvironmentVariableArgs(name="EVENT_API_URL", value=pulumi.Output.concat("https://api.", domain, "/events")),
@@ -815,7 +815,7 @@ def origin_group(name: str, probe_path: str, host: pulumi.Input[str], port: int)
     )
     return og, origin
 
-ui_og, ui_origin   = origin_group("ui",    "/",           ui_cg.ip_address.apply(lambda ip: ip.fqdn), 443)
+ui_og, ui_origin   = origin_group("ui",    "/",           ui_cg.ip_address.apply(lambda ip: ip.fqdn), 80)
 api_og, api_origin  = origin_group("api",   "/api/health", func_app.default_host_name,                443)
 voice_og, voice_origin = origin_group("voice", "/",           voice_cg.ip_address.apply(lambda ip: ip.fqdn), 8081)
 
@@ -852,8 +852,8 @@ def afd_route(name, pattern, og, origin, cd, fp):
         custom_domains=[cdn.ActivatedResourceReferenceArgs(id=cd.id)],
         opts=pulumi.ResourceOptions(depends_on=[og, origin]),
     )
-afd_route("ui",    "/*",           ui_og, ui_origin,   ui_cd,   cdn.ForwardingProtocol.HTTPS_ONLY)
-afd_route("api",   "/api/*",       api_og, api_origin,  api_cd,  cdn.ForwardingProtocol.HTTPS_ONLY)
+afd_route("ui",    "/*",           ui_og, ui_origin,   ui_cd,   cdn.ForwardingProtocol.HTTP_ONLY)
+afd_route("api",   "/api/*",       api_og, api_origin,  api_cd,  cdn.ForwardingProtocol.HTTP_ONLY)
 afd_route("voice", "/voice-ws/*",  voice_og, voice_origin, voice_cd, cdn.ForwardingProtocol.HTTP_ONLY)
 
 dns_zone = dns.Zone(


### PR DESCRIPTION
## Summary
- expose port 80 in chat client image and scripts
- update chat client docs for port 80
- update authentication guide to match
- adjust deployment test guide instructions
- configure Pulumi to use HTTP origins and routing

## Testing
- `pip install -r requirements-worker.txt`
- `pytest -q`
- `python check-gh-actions.py` *(fails: gh run list returned non-zero exit status 4)*

------
https://chatgpt.com/codex/tasks/task_e_684cfc7e41fc832eaf34d143f1d457bf