### PR TITLE
Fix /auth root

### DIFF
--- a/chat_client/auth_app.py
+++ b/chat_client/auth_app.py
@@ -44,6 +44,19 @@ app.add_middleware(SessionMiddleware, secret_key=SESSION_SECRET)
 templates = Jinja2Templates(directory="templates")
 
 
+@app.get("/", response_class=HTMLResponse)
+async def root(request: Request):
+    """Login page or redirect if already authenticated."""
+    token = request.cookies.get("auth_token")
+    if token:
+        try:
+            verify_token(token)
+            return RedirectResponse(url="/chat")
+        except Exception:
+            pass
+    return templates.TemplateResponse("login.html", {"request": request})
+
+
 @app.get("/login")
 async def login(request: Request):
     """Redirect user to Azure login."""


### PR DESCRIPTION
## Summary
- add root handler for `/auth` to display login page or redirect if already logged in

## Testing
- `pip install -r requirements-worker.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d1968fdcc832ebe0576c04fd1ed79