### PR TITLE
Fix registration route

### DIFF
--- a/chat_client/auth_app.py
+++ b/chat_client/auth_app.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import RedirectResponse, HTMLResponse
+import requests
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware
 import msal
@@ -27,6 +28,7 @@ AAD_CLIENT_SECRET = (
     or os.environ.get("AZURE_CLIENT_SECRET")
 )
 SESSION_SECRET = os.environ.get("SESSION_SECRET", "change-me")
+AUTH_API_URL = os.environ.get("AUTH_API_URL", "/api")
 
 if not (AAD_CLIENT_ID and AAD_TENANT_ID and AAD_CLIENT_SECRET):
     logging.warning("AAD configuration incomplete")
@@ -118,6 +120,42 @@ async def chat_redirect(request: Request):
     except Exception:
         return RedirectResponse(url="/login")
     return RedirectResponse(_resolve_chainlit_url(request))
+
+
+@app.get("/register", response_class=HTMLResponse)
+async def register_form(request: Request):
+    """Display the registration page."""
+    return templates.TemplateResponse("register.html", {"request": request})
+
+
+@app.post("/register")
+async def register_user(request: Request):
+    """Handle user registration via Azure Function."""
+    form = await request.form()
+    username = form.get("username")
+    email = form.get("email")
+    password = form.get("password")
+    confirm = form.get("confirm_password")
+
+    if password != confirm:
+        return RedirectResponse("/register?error=password_mismatch", status_code=303)
+    if not password or len(password) < 6:
+        return RedirectResponse("/register?error=password_too_short", status_code=303)
+
+    try:
+        resp = requests.post(
+            f"{AUTH_API_URL.rstrip('/')}/auth/register",
+            json={"username": username, "password": password, "email": email},
+            timeout=10,
+        )
+    except Exception:
+        return RedirectResponse("/register?error=service_unavailable", status_code=303)
+
+    if resp.status_code in (200, 201):
+        return RedirectResponse("/?message=registration_waitlist", status_code=303)
+    if resp.status_code == 409:
+        return RedirectResponse("/register?error=username_exists", status_code=303)
+    return RedirectResponse("/register?error=service_error", status_code=303)
 
 
 @app.get("/health")

--- a/chat_client/gateway_app.py
+++ b/chat_client/gateway_app.py
@@ -22,6 +22,12 @@ async def root():
     """Redirect to the authentication gateway."""
     return RedirectResponse(url="/auth")
 
+
+@app.get("/register", include_in_schema=False)
+async def register_root():
+    """Legacy registration path for convenience."""
+    return RedirectResponse(url="/auth/register")
+
 @app.get("/health")
 async def health():
     return {"status": "ok"}

--- a/chat_client/templates/login.html
+++ b/chat_client/templates/login.html
@@ -232,7 +232,7 @@
             </form>
 
             <div class="auth-links">
-                <p>Don't have an account? <a href="/register">Create one here</a></p>
+                <p>Don't have an account? <a href="/auth/register">Create one here</a></p>
                 <p style="margin-top: 10px; font-size: 0.9em; color: #6b7280;">
                     Admin? <a href="/admin" style="color: #667eea;">Access Admin Panel</a>
                 </p>


### PR DESCRIPTION
## Summary
- expose AUTH_API_URL for auth gateway
- implement /auth/register GET and POST routes
- add /register redirect in the main gateway
- fix login page link

## Testing
- `pip install -r requirements-worker.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d221169cc832eb69a8da18f89b5c6