### PR TITLE
Fix registration form path

### DIFF
--- a/chat_client/templates/register.html
+++ b/chat_client/templates/register.html
@@ -159,7 +159,7 @@
             </div>
         {% endif %}
         
-        <form action="/register" method="post">
+        <form action="/auth/register" method="post">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
             <div class="form-group">
                 <label for="username">Username</label>


### PR DESCRIPTION
## Summary
- point registration form to `/auth/register`

## Testing
- `pip install -r requirements-worker.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d278b964c832e856db49905bed12b