### PR TITLE
Ensure workers can access context hub

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -6,6 +6,8 @@ WORKDIR /app
 COPY agents/ ./agents/
 COPY events/ ./events/
 COPY worker.py ./
+COPY contexthub /usr/local/bin/contexthub
+RUN chmod +x /usr/local/bin/contexthub
 
 # Create a requirements.txt for the worker container
 COPY requirements-worker.txt ./requirements.txt

--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ Functions Core Tools) or through a `.env` file in the repository root.
     "USER_CONTAINER": "users",
     "REPO_CONTAINER": "repos",
     "SCHEDULE_CONTAINER": "schedules",
-    "TASK_CONTAINER": "tasks"
+    "TASK_CONTAINER": "tasks",
+    "HUB_URL": "http://localhost:3000"
   }
 }
 ```
@@ -260,6 +261,7 @@ USER_CONTAINER=users
 REPO_CONTAINER=repos
 SCHEDULE_CONTAINER=schedules
 TASK_CONTAINER=tasks
+HUB_URL=http://localhost:3000
 ACS_CONNECTION=<acs-connection>
 ACS_SENDER=no-reply@example.com
 VERIFY_BASE_URL=https://localhost
@@ -335,6 +337,10 @@ The `agents/` directory contains agent implementations that the worker container
 invoke to process tasks. Each agent registers itself in `agents.AGENT_REGISTRY`
 and exposes a `run()` method used to handle the commands from a
 `WorkerTaskEvent`.
+
+All worker images include the `contexthub` CLI tool. Agents can invoke this
+command (or use the `Agent.hub()` helper) to interact with the deployed Context
+Hub service defined by the `HUB_URL` environment variable.
 
 ## Tests
 

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,6 +1,8 @@
 """Agents available to run worker tasks."""
 
 from typing import Dict, List
+import subprocess
+import sys
 
 
 class Agent:
@@ -8,9 +10,20 @@ class Agent:
 
     name: str = "base"
 
+    hub_cli: str = "contexthub"
+
     def run(self, commands: List[str]) -> str:
         """Execute the provided commands and return a result string."""
         raise NotImplementedError()
+
+    def hub(self, *args: str) -> str:
+        """Invoke the context hub CLI with the given arguments."""
+        cmd = [self.hub_cli, *args]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+        result.check_returncode()
+        return result.stdout
 
 
 AGENT_REGISTRY: Dict[str, Agent] = {}

--- a/azure-function/WorkerTaskRunner/__init__.py
+++ b/azure-function/WorkerTaskRunner/__init__.py
@@ -102,6 +102,7 @@ def main(msg: func.ServiceBusMessage) -> None:
             EnvironmentVariable(name="COSMOS_CONNECTION", value=COSMOS_CONN or ""),
             EnvironmentVariable(name="COSMOS_DATABASE", value=COSMOS_DB),
             EnvironmentVariable(name="TASK_CONTAINER", value=TASK_CONTAINER),
+            EnvironmentVariable(name="HUB_URL", value=os.environ.get("HUB_URL", "")),
         ]
         container = Container(
             name="worker",

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -622,6 +622,7 @@ hub_cg = aci_group(
     3000,
     [],
 )
+hub_url = hub_cg.ip_address.apply(lambda ip: f"http://{ip.ip}:3000")
 
 pulumi.export("uiFqdn", ui_cg.ip_address.apply(lambda ip: ip.fqdn))
 pulumi.export("voiceWsFqdn", voice_cg.ip_address.apply(lambda ip: ip.fqdn))
@@ -726,6 +727,7 @@ func_settings = {
     "AAD_CLIENT_SECRET": aad_password.value,
     "AAD_TENANT_ID": aad_tenant_id,
     "NOTIFY_URL": pulumi.Output.concat("https://www.", domain, "/chat/notify"),
+    "HUB_URL": hub_url,
 }
 web.WebAppApplicationSettings(
     "func-settings",


### PR DESCRIPTION
## Summary
- include `contexthub` CLI in worker image
- expose `hub_url` via infrastructure outputs
- pass `HUB_URL` to worker containers
- add a helper method to all agents for calling the CLI
- document the new variable and CLI availability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6a1ff95c832e9b6af87553a2e2f5