### PR TITLE
Improve scheduler cron parsing

### DIFF
--- a/agents/requirements-worker.txt
+++ b/agents/requirements-worker.txt
@@ -9,3 +9,4 @@ jinja2>=3.1.0
 PyJWT>=2.8.0
 pytest-benchmark
 click>=8.1.0
+croniter

--- a/vextir_os/orchestration_drivers.py
+++ b/vextir_os/orchestration_drivers.py
@@ -719,11 +719,17 @@ class SchedulerDriver(ToolDriver):
     
     def _calculate_next_trigger(self, cron_expression: str) -> str:
         """Calculate the next trigger time for a cron expression"""
-        # TODO: Implement proper cron parsing
-        # For now, return a placeholder time (1 hour from now)
-        from datetime import timedelta
-        next_time = datetime.utcnow() + timedelta(hours=1)
-        return next_time.isoformat()
+        try:
+            from croniter import croniter
+            base_time = datetime.utcnow()
+            next_time = croniter(cron_expression, base_time).get_next(datetime)
+            return next_time.isoformat()
+        except Exception as e:
+            # Fall back to one hour from now if the expression is invalid
+            logging.error(f"Invalid cron expression '{cron_expression}': {e}")
+            from datetime import timedelta
+            next_time = datetime.utcnow() + timedelta(hours=1)
+            return next_time.isoformat()
 
 
 # Function to register all orchestration drivers


### PR DESCRIPTION
## Summary
- enable cron-based next trigger calculation in `SchedulerDriver`
- include `croniter` in worker requirements

## Testing
- `pip install -r agents/requirements-worker.txt`
- `pytest -q` *(fails: ImportError in tests/test_driver_migration.py)*
- `pytest tests/test_scheduler.py -q` *(fails: FileNotFoundError for Scheduler Azure Function modules)*

------
https://chatgpt.com/codex/tasks/task_e_684f0ad77dc4832eb85417796dea6adb