### PR TITLE
Update CLI hub defaults

### DIFF
--- a/vextir_cli/CONTEXT_HUB_INTEGRATION_GUIDE.md
+++ b/vextir_cli/CONTEXT_HUB_INTEGRATION_GUIDE.md
@@ -138,7 +138,7 @@ Context Hub settings are part of the main CLI configuration:
 vextir config get
 
 # Set Context Hub specific settings
-vextir config set context_hub.endpoint https://my-hub.example.com
+vextir config set context_hub.endpoint https://hub.vextir.com
 vextir config set context_hub.default_path /my-workspace
 ```
 

--- a/vextir_cli/ENHANCED_CLI_COMPLETE.md
+++ b/vextir_cli/ENHANCED_CLI_COMPLETE.md
@@ -176,7 +176,7 @@ The CLI integrates the existing `contexthub-cli.py` providing:
 
 ```bash
 # Set Context Hub endpoint
-vextir config set context_hub.endpoint http://localhost:3000
+vextir config set context_hub.endpoint https://hub.vextir.com
 
 # Configure user for Context Hub
 vextir config set auth.username your_username

--- a/vextir_cli/config.py
+++ b/vextir_cli/config.py
@@ -66,7 +66,7 @@ class Config:
             "context_hub": {
                 "default_path": "/",
                 "max_query_results": 1000,
-                "endpoint": "http://10.0.1.4:3000"
+                "endpoint": "https://hub.vextir.com"
             }
         }
     

--- a/vextir_cli/install.sh
+++ b/vextir_cli/install.sh
@@ -147,7 +147,8 @@ create_config() {
   },
   "context_hub": {
     "default_path": "/",
-    "max_query_results": 1000
+    "max_query_results": 1000,
+    "endpoint": "https://hub.vextir.com"
   }
 }
 EOF

--- a/vextir_cli/main.py
+++ b/vextir_cli/main.py
@@ -1127,9 +1127,7 @@ def get_hub_config(ctx):
     # Auto-configure Context Hub endpoint if not set
     hub_endpoint = config_obj.get('context_hub.endpoint')
     if not hub_endpoint:
-        # Use the same endpoint as the main Vextir OS but with context hub path
-        main_endpoint = config_obj.get('endpoint', 'https://test-vextir.azurewebsites.net')
-        hub_endpoint = f"{main_endpoint}/api/context-hub"
+        hub_endpoint = 'https://hub.vextir.com'
         config_obj.set('context_hub.endpoint', hub_endpoint)
     
     # Get current user from Azure CLI


### PR DESCRIPTION
## Summary
- default to using prod Context Hub at https://hub.vextir.com
- update auto configuration logic in CLI
- include endpoint in install script
- update documentation to mention new hub URL

## Testing
- `python vextir_cli/test_cli.py`
- `pytest vextir_cli/test_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0b55a774832e9fa3a20ae28a6f07