### PR TITLE
Add flake8 linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 120
+per-file-ignores =
+    agents/conseil/codex-cli/examples/prompt-analyzer/template/cluster_prompts.py: E203,F841
+    agents/conseil/scripts/readme_toc.py: E203,E741
+    agents/conseil_agent.py: E302

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,29 @@ env:
   AZURE_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r agents/requirements-worker.txt
+          pip install flake8
+
+      - name: Run flake8
+        run: flake8 agents
+
   # Build Docker images in parallel - no dependency on infrastructure
   build-images:
+    needs: lint
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -65,6 +86,7 @@ jobs:
 
   # Deploy infrastructure - can start immediately, just needs to wait for images at the end
   deploy-infrastructure:
+    needs: lint
     runs-on: ubuntu-latest
     outputs:
       pulumi-configured: ${{ steps.setup.outputs.configured }}

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -3,6 +3,8 @@
 from typing import Dict, List
 import subprocess
 import sys
+from . import echo_agent  # noqa: F401  # register built-in agents
+from . import conseil_agent  # noqa: F401
 
 
 class Agent:
@@ -38,5 +40,3 @@ def register(agent_cls: type) -> type:
     return agent_cls
 
 
-from . import echo_agent  # noqa: F401  # register built-in agents
-from . import conseil_agent  # noqa: F401

--- a/agents/conseil/codex-cli/examples/prompt-analyzer/template/cluster_prompts.py
+++ b/agents/conseil/codex-cli/examples/prompt-analyzer/template/cluster_prompts.py
@@ -399,7 +399,8 @@ def generate_markdown_report(
     lines.append("\n---\n")
     lines.append("## Plots\n")
     lines.append(
-        "The directory `plots/` contains a bar chart of the cluster sizes and a t‑SNE scatter plot coloured by cluster.\n"
+        "The directory `plots/` contains a bar chart of the cluster sizes "
+        "and a t‑SNE scatter plot coloured by cluster.\n"
     )
 
     path_md.write_text("\n".join(lines))


### PR DESCRIPTION
## Summary
- configure Flake8 with per-file ignores
- fix import ordering in `agents/__init__.py`
- wrap long string in prompt analyzer example
- run flake8 in CI before building images

## Testing
- `flake8 agents`


------
https://chatgpt.com/codex/tasks/task_e_684f16e41ce0832ea4d2ff4aa6104c6b