### PR TITLE
Add Linux system status event generator

### DIFF
--- a/events/eventgen/laptop/README.md
+++ b/events/eventgen/laptop/README.md
@@ -9,3 +9,10 @@ Possible data sources include:
 - Network status
 
 Scripts should format the data as events so they can be queued to the backend.
+
+The `linux` directory now includes `system_status.py` which emits battery, CPU,
+memory and network events. Run it with:
+
+```bash
+python linux/system_status.py
+```

--- a/events/eventgen/laptop/linux/README.md
+++ b/events/eventgen/laptop/linux/README.md
@@ -1,9 +1,19 @@
 # Linux
 
-This directory will hold tools for collecting laptop information on Linux distributions, e.g.:
+Utilities here gather laptop information on Linux distributions. Metrics are
+formatted as `Event` objects so they can be queued to the backend.
 
-- Battery level from `/sys/class/power_supply`.
-- Current network status via `nmcli` or `ip`.
-- CPU load and memory consumption from `/proc`.
+`system_status.py` collects several basic statistics using standard system
+interfaces:
 
-Collected metrics should be packaged as `Event` objects for dispatching.
+- **laptop.battery** – percentage and charging status from
+  `/sys/class/power_supply` when available.
+- **laptop.cpu** – load average from `os.getloadavg()`.
+- **laptop.memory** – total and available memory parsed from `/proc/meminfo`.
+- **laptop.network** – hostname and IP address.
+
+Run the script directly to print each event as a JSON object:
+
+```bash
+python system_status.py
+```

--- a/events/eventgen/laptop/linux/system_status.py
+++ b/events/eventgen/laptop/linux/system_status.py
@@ -1,0 +1,124 @@
+import os
+import json
+import socket
+import getpass
+from datetime import datetime
+from typing import List, Optional, Tuple
+
+from events import Event
+
+
+def _read_first(path: str) -> Optional[str]:
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except Exception:
+        return None
+
+
+def get_battery_status() -> Tuple[Optional[int], Optional[bool]]:
+    """Return (percentage, charging) from /sys/class/power_supply if available."""
+    base = "/sys/class/power_supply"
+    if not os.path.isdir(base):
+        return None, None
+    for name in os.listdir(base):
+        if name.startswith("BAT"):
+            percent = _read_first(os.path.join(base, name, "capacity"))
+            status = _read_first(os.path.join(base, name, "status"))
+            try:
+                percent_val = int(percent) if percent is not None else None
+            except Exception:
+                percent_val = None
+            charging = status.lower() == "charging" if status else None
+            return percent_val, charging
+    return None, None
+
+
+def get_cpu_load() -> Optional[Tuple[float, float, float]]:
+    try:
+        return os.getloadavg()
+    except Exception:
+        return None
+
+
+def get_memory_usage() -> Tuple[Optional[int], Optional[int]]:
+    """Return (total_kb, available_kb) from /proc/meminfo."""
+    try:
+        info = {}
+        with open("/proc/meminfo") as f:
+            for line in f:
+                key, rest = line.split(":", 1)
+                value = rest.strip().split()[0]
+                info[key] = int(value)
+        return info.get("MemTotal"), info.get("MemAvailable")
+    except Exception:
+        return None, None
+
+
+def get_network_info() -> Tuple[str, Optional[str]]:
+    hostname = socket.gethostname()
+    try:
+        ip = socket.gethostbyname(hostname)
+    except Exception:
+        ip = None
+    return hostname, ip
+
+
+def collect_events(user_id: Optional[str] = None) -> List[Event]:
+    user_id = user_id or getpass.getuser()
+    events: List[Event] = []
+    now = datetime.utcnow()
+
+    load_avg = get_cpu_load()
+    if load_avg is not None:
+        events.append(
+            Event(
+                timestamp=now,
+                source="linux.laptop",
+                type="laptop.cpu",
+                user_id=user_id,
+                metadata={"load_avg": list(load_avg)},
+            )
+        )
+
+    total_kb, avail_kb = get_memory_usage()
+    if total_kb is not None:
+        events.append(
+            Event(
+                timestamp=now,
+                source="linux.laptop",
+                type="laptop.memory",
+                user_id=user_id,
+                metadata={"total_kb": total_kb, "available_kb": avail_kb},
+            )
+        )
+
+    percent, charging = get_battery_status()
+    if percent is not None:
+        events.append(
+            Event(
+                timestamp=now,
+                source="linux.laptop",
+                type="laptop.battery",
+                user_id=user_id,
+                metadata={"percentage": percent, "charging": charging},
+            )
+        )
+
+    hostname, ip = get_network_info()
+    events.append(
+        Event(
+            timestamp=now,
+            source="linux.laptop",
+            type="laptop.network",
+            user_id=user_id,
+            metadata={"hostname": hostname, "ip": ip},
+        )
+    )
+
+    return events
+
+
+if __name__ == "__main__":
+    for event in collect_events():
+        print(json.dumps(event.to_dict()))

--- a/tests/test_system_status.py
+++ b/tests/test_system_status.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from events.eventgen.laptop.linux import system_status
+from events import Event
+
+
+def test_collect_events():
+    events = system_status.collect_events(user_id="tester")
+    assert isinstance(events, list) and events
+    assert all(isinstance(e, Event) for e in events)
+    types = {e.type for e in events}
+    # CPU and memory events should always be present
+    assert "laptop.cpu" in types
+    assert "laptop.memory" in types


### PR DESCRIPTION
## Summary
- implement `system_status.py` for Linux laptop event generation
- document new script and usage instructions
- provide usage notes in parent laptop README
- add unit test for the generator

## Testing
- `pytest tests/test_system_status.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684f17370e80832e91c8026b570ea9c6