### PR TITLE
Implement OAuth-based comms

### DIFF
--- a/docs/EMAIL_CALENDAR_INTEGRATION_COMPLETE.md
+++ b/docs/EMAIL_CALENDAR_INTEGRATION_COMPLETE.md
@@ -181,6 +181,10 @@ GMAIL_CLIENT_ID=your_gmail_client_id
 GMAIL_CLIENT_SECRET=your_gmail_client_secret
 OUTLOOK_CLIENT_ID=your_outlook_client_id
 OUTLOOK_CLIENT_SECRET=your_outlook_client_secret
+GMAIL_OAUTH_TOKEN=your_gmail_access_token
+OUTLOOK_OAUTH_TOKEN=your_outlook_access_token
+ICLOUD_USERNAME=your_icloud_email
+ICLOUD_APP_PASSWORD=your_icloud_app_password
 
 # Service Bus
 SERVICE_BUS_CONNECTION_STRING=your_service_bus_connection

--- a/docs/EMAIL_CALENDAR_INTEGRATION_GUIDE.md
+++ b/docs/EMAIL_CALENDAR_INTEGRATION_GUIDE.md
@@ -254,6 +254,10 @@ SERVICEBUS_QUEUE=<queue_name>
 HUB_URL=<context_hub_url>
 OPENAI_API_KEY=<openai_api_key>
 INSTRUCTION_CONTAINER=instructions
+GMAIL_OAUTH_TOKEN=<gmail_access_token>
+OUTLOOK_OAUTH_TOKEN=<outlook_access_token>
+ICLOUD_USERNAME=<icloud_email>
+ICLOUD_APP_PASSWORD=<icloud_app_password>
 ```
 
 ### 3. Webhook Registration

--- a/docs/EMAIL_CALENDAR_SYSTEM_COMPLETE.md
+++ b/docs/EMAIL_CALENDAR_SYSTEM_COMPLETE.md
@@ -290,6 +290,10 @@ SERVICEBUS_CONNECTION=<servicebus_connection_string>
 OPENAI_API_KEY=<openai_api_key>
 GMAIL_CLIENT_ID=<gmail_oauth_client_id>
 OUTLOOK_CLIENT_ID=<outlook_oauth_client_id>
+GMAIL_OAUTH_TOKEN=<gmail_access_token>
+OUTLOOK_OAUTH_TOKEN=<outlook_access_token>
+ICLOUD_USERNAME=<icloud_email>
+ICLOUD_APP_PASSWORD=<icloud_app_password>
 ```
 
 ### Provider Setup

--- a/tests/test_communication_api_calls.py
+++ b/tests/test_communication_api_calls.py
@@ -1,0 +1,134 @@
+import asyncio
+import types
+import sys
+import os
+import smtplib
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from vextir_os.communication_drivers import EmailConnectorDriver, CalendarConnectorDriver
+
+
+def setup_driver_env(monkeypatch):
+    monkeypatch.setenv("GMAIL_OAUTH_TOKEN", "tok")
+    monkeypatch.setenv("OUTLOOK_OAUTH_TOKEN", "otok")
+    monkeypatch.setenv("ICLOUD_USERNAME", "user@icloud.com")
+    monkeypatch.setenv("ICLOUD_APP_PASSWORD", "pass")
+
+
+def test_send_via_gmail(monkeypatch):
+    setup_driver_env(monkeypatch)
+    captured = {}
+
+    def fake_post(url, headers=None, json=None):
+        captured['url'] = url
+        captured['headers'] = headers
+        captured['json'] = json
+        return types.SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr('requests.post', fake_post)
+
+    driver = EmailConnectorDriver(EmailConnectorDriver._vextir_manifest)
+    res = asyncio.run(driver._send_via_gmail('u', {'to': 'a@example.com', 'subject': 's', 'body': 'b'}))
+    assert res is True
+    assert captured['url'].startswith('https://gmail')
+    assert 'Bearer tok' in captured['headers']['Authorization']
+
+def test_send_via_outlook(monkeypatch):
+    setup_driver_env(monkeypatch)
+    captured = {}
+
+    def fake_post(url, headers=None, json=None):
+        captured['url'] = url
+        captured['headers'] = headers
+        captured['json'] = json
+        return types.SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr('requests.post', fake_post)
+
+    driver = EmailConnectorDriver(EmailConnectorDriver._vextir_manifest)
+    res = asyncio.run(driver._send_via_outlook('u', {'to': 'a@example.com', 'subject': 's', 'body': 'b'}))
+    assert res is True
+    assert captured['url'].startswith('https://graph.microsoft.com')
+    assert 'Bearer otok' in captured['headers']['Authorization']
+
+def test_send_via_icloud(monkeypatch):
+    setup_driver_env(monkeypatch)
+    captured = {}
+
+    class DummySMTP:
+        def __init__(self, host, port):
+            captured['host'] = host
+            captured['port'] = port
+        def login(self, user, pwd):
+            captured['login'] = (user, pwd)
+        def sendmail(self, from_addr, to_addrs, msg):
+            captured['msg'] = msg
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            pass
+
+    monkeypatch.setattr(smtplib, 'SMTP_SSL', DummySMTP)
+
+    driver = EmailConnectorDriver(EmailConnectorDriver._vextir_manifest)
+    res = asyncio.run(driver._send_via_icloud('u', {'to': 'a@example.com', 'subject': 's', 'body': 'b'}))
+    assert res is True
+    assert captured['login'] == ('user@icloud.com', 'pass')
+
+def test_create_via_google_calendar(monkeypatch):
+    setup_driver_env(monkeypatch)
+    captured = {}
+
+    def fake_post(url, headers=None, json=None):
+        captured['url'] = url
+        captured['headers'] = headers
+        captured['json'] = json
+        return types.SimpleNamespace(status_code=201)
+
+    monkeypatch.setattr('requests.post', fake_post)
+
+    driver = CalendarConnectorDriver(CalendarConnectorDriver._vextir_manifest)
+    res = asyncio.run(driver._create_via_google_calendar('u', {'title': 't', 'start_time': 's', 'end_time': 'e'}))
+    assert res is True
+    assert captured['url'].startswith('https://www.googleapis.com/calendar')
+    assert 'Bearer tok' in captured['headers']['Authorization']
+
+def test_create_via_outlook_calendar(monkeypatch):
+    setup_driver_env(monkeypatch)
+    captured = {}
+
+    def fake_post(url, headers=None, json=None):
+        captured['url'] = url
+        captured['headers'] = headers
+        captured['json'] = json
+        return types.SimpleNamespace(status_code=201)
+
+    monkeypatch.setattr('requests.post', fake_post)
+
+    driver = CalendarConnectorDriver(CalendarConnectorDriver._vextir_manifest)
+    res = asyncio.run(driver._create_via_outlook_calendar('u', {'title': 't', 'start_time': 's', 'end_time': 'e'}))
+    assert res is True
+    assert captured['url'].startswith('https://graph.microsoft.com')
+    assert 'Bearer otok' in captured['headers']['Authorization']
+
+def test_create_via_icloud_calendar(monkeypatch):
+    setup_driver_env(monkeypatch)
+    captured = {}
+
+    def fake_post(url, data=None, headers=None, auth=None):
+        captured['url'] = url
+        captured['data'] = data
+        captured['headers'] = headers
+        captured['auth'] = auth
+        return types.SimpleNamespace(status_code=201)
+
+    monkeypatch.setattr('requests.post', fake_post)
+
+    driver = CalendarConnectorDriver(CalendarConnectorDriver._vextir_manifest)
+    res = asyncio.run(driver._create_via_icloud_calendar('u', {'title': 't', 'start_time': 's', 'end_time': 'e'}))
+    assert res is True
+    assert captured['auth'] == ('user@icloud.com', 'pass')
+


### PR DESCRIPTION
## Summary
- add credential configuration for Gmail, Outlook and iCloud
- implement real email and calendar API calls
- document new environment variables
- test drivers using mocked API calls

## Testing
- `pip install -r agents/requirements-worker.txt`
- `pytest -k communication_api_calls -q`

------
https://chatgpt.com/codex/tasks/task_e_684f16e09874832ebfdd0ce0fd2c85be