### PR TITLE
Make lint job informative

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -39,7 +40,6 @@ jobs:
 
   # Build Docker images in parallel - no dependency on infrastructure
   build-images:
-    needs: lint
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -86,7 +86,6 @@ jobs:
 
   # Deploy infrastructure - can start immediately, just needs to wait for images at the end
   deploy-infrastructure:
-    needs: lint
     runs-on: ubuntu-latest
     outputs:
       pulumi-configured: ${{ steps.setup.outputs.configured }}


### PR DESCRIPTION
## Summary
- make `lint` job continue on errors
- parallelize lint job with others by dropping job dependency

## Testing
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684f6f534104832ead25d20154185bb7