### PR TITLE
Fix Docker build context for context-hub

### DIFF
--- a/context-hub/Dockerfile
+++ b/context-hub/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 rust:1.76-slim AS build
 WORKDIR /app
-COPY context-hub/ ./
+COPY . ./
 RUN rustup target add x86_64-unknown-linux-musl \
     && cargo build --release --target x86_64-unknown-linux-musl
 


### PR DESCRIPTION
## Summary
- fix `COPY` statement in context-hub Dockerfile

## Testing
- `cargo test --workspace --exclude context-hub-fuse` *(fails: api::tests::folder_listing)*
- `pytest -q` *(fails to collect tests)*

------
https://chatgpt.com/codex/tasks/task_e_684f71fc0ca4832ea9a1d8654293c1c6