### PR TITLE
Update Rust base image versions

### DIFF
--- a/context-hub/Dockerfile
+++ b/context-hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust:1.76-slim AS build
+FROM --platform=linux/amd64 rust:1.78-slim AS build
 WORKDIR /app
 COPY . ./
 RUN rustup target add x86_64-unknown-linux-musl \

--- a/context-hub/Dockerfile.contexthub
+++ b/context-hub/Dockerfile.contexthub
@@ -1,4 +1,4 @@
-FROM rust:1.72-slim AS build
+FROM rust:1.78-slim AS build
 WORKDIR /build
 COPY . ./context-hub
 WORKDIR /build/context-hub


### PR DESCRIPTION
## Summary
- update Context Hub Dockerfiles to Rust 1.78

## Testing
- `pytest` *(fails: ImportError: cannot import name 'Agent')*

------
https://chatgpt.com/codex/tasks/task_e_684f750fbc34832e901e9d27aeb19166