### PR TITLE
Fix job dependencies and circular import

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
 
   # Build Docker images in parallel - no dependency on infrastructure
   build-images:
-    needs: [check-acr, deploy-baseline]
+    needs: check-acr
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -178,7 +178,7 @@ jobs:
   # Final deployment with actual images
   deploy-with-images:
     runs-on: ubuntu-latest
-    needs: [build-images, deploy-baseline]
+    needs: build-images
     steps:
       - uses: actions/checkout@v4
       

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -3,8 +3,6 @@
 from typing import Dict, List
 import subprocess
 import sys
-from . import echo_agent  # noqa: F401  # register built-in agents
-from . import conseil_agent  # noqa: F401
 
 
 class Agent:
@@ -38,3 +36,7 @@ def register(agent_cls: type) -> type:
         raise TypeError("agent_cls must inherit from Agent")
     AGENT_REGISTRY[instance.name] = instance
     return agent_cls
+
+
+from . import echo_agent  # noqa: F401  # register built-in agents
+from . import conseil_agent  # noqa: F401


### PR DESCRIPTION
## Summary
- fix `build-images` job dependency so it doesn't rely on skipped `deploy-baseline`
- update `deploy-with-images` job to depend only on image build
- rearrange agent imports to avoid circular import during tests

## Testing
- `pip install -r agents/requirements-worker.txt`
- `pytest -q` *(fails: ImportError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_684f79be9fcc832e8e0267a3e470154f