### PR TITLE
Fix context hub build

### DIFF
--- a/context-hub/Dockerfile
+++ b/context-hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust:1.78-slim AS build
+FROM --platform=linux/amd64 rust:1.87-slim AS build
 WORKDIR /app
 COPY . ./
 RUN rustup target add x86_64-unknown-linux-musl \

--- a/context-hub/Dockerfile.contexthub
+++ b/context-hub/Dockerfile.contexthub
@@ -1,4 +1,4 @@
-FROM rust:1.78-slim AS build
+FROM rust:1.87-slim AS build
 WORKDIR /build
 COPY . ./context-hub
 WORKDIR /build/context-hub


### PR DESCRIPTION
## Summary
- update Rust base images for context hub

## Testing
- `pytest -q` *(fails: KeyError: 'model', FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684f7d13a9a4832e9dfa6f51effefd92