### PR TITLE
Fix context-hub Docker build for musl target

### DIFF
--- a/context-hub/Dockerfile
+++ b/context-hub/Dockerfile
@@ -1,7 +1,11 @@
 FROM --platform=linux/amd64 rust:1.87-slim AS build
 WORKDIR /app
 COPY . ./
-RUN rustup target add x86_64-unknown-linux-musl \
+RUN apt-get update && apt-get install -y \
+        cmake \
+        pkg-config \
+        musl-tools \
+    && rustup target add x86_64-unknown-linux-musl \
     && cargo build --release --target x86_64-unknown-linux-musl
 
 FROM --platform=linux/amd64 debian:bookworm-slim

--- a/context-hub/context-hub-core/Cargo.toml
+++ b/context-hub/context-hub-core/Cargo.toml
@@ -10,7 +10,7 @@ serde_json = "1"
 loro = "1"
 uuid = { version = "1", features = ["v4"] }
 anyhow = "1"
-git2 = "0.18"
+git2 = { version = "0.18", features = ["vendored-openssl"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 tantivy = { version = "0.19", default-features = false, features = ["lz4-compression", "mmap"] }
 tokio-stream = { version = "0.1", features = ["sync"] }


### PR DESCRIPTION
## Summary
- install build tools when compiling context-hub
- use vendored OpenSSL for git2 to avoid missing system libraries

## Testing
- `pip install -r agents/requirements-worker.txt`
- `pip install -e vextir_os`
- `pytest` *(fails: KeyError: 'model', AssertionError: assert 202 == 401, AssertionError: assert '...)*

------
https://chatgpt.com/codex/tasks/task_e_684f83d8e300832e85c58c0add130dd0