### PR TITLE
Fix Docker image build with new pulumi_docker APIs

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -358,12 +358,12 @@ acr_creds = containerregistry.list_registry_credentials_output(
 if hub_image_cfg.startswith(f"vextiracr{stack_suffix}.azurecr.io"):
     hub_image = docker.Image(
         "context-hub-image",
-        build=docker.DockerBuild(
+        build=docker.DockerBuildArgs(
             context=str(Path(__file__).parent.parent / "context-hub"),
             platform="linux/amd64",
         ),
         image_name=hub_image_cfg,
-        registry=docker.ImageRegistry(
+        registry=docker.RegistryArgs(
             server=acr.login_server,
             username=acr_creds.username,
             password=acr_creds.passwords[0].value,


### PR DESCRIPTION
## Summary
- update `infra/__main__.py` to use `DockerBuildArgs` and `RegistryArgs` with pulumi_docker 4.x

## Testing
- `pip install -r agents/requirements-worker.txt --quiet`
- `pytest -q` *(fails: KeyError: 'model', AssertionError: assert 202 == 401, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_684f8dad9ed0832eb2cbeeb67b28301b