### PR TITLE
Fix UI startup script and enable domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -227,3 +227,13 @@ jobs:
           pulumi up --yes --skip-preview
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Activate Front Door endpoint
+        run: |
+          az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
+          az account set --subscription $ARM_SUBSCRIPTION_ID
+          az afd endpoint update \
+            -g vextir-dev \
+            --profile-name vextir-fd-dev \
+            --endpoint-name vextir-ep-dev \
+            --enabled-state Enabled

--- a/ui/chat_client/Dockerfile
+++ b/ui/chat_client/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.11-slim
 
+# Install bash since the startup script relies on bash-specific features
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends bash && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # Copy the chat client code and dependencies
@@ -10,7 +15,8 @@ COPY ui/chat_client/static/ ./static/
 COPY ui/chat_client/start.sh ./start.sh
 COPY ui/chat_client/gateway_app.py ./gateway_app.py
 COPY events/ ./events/
-COPY ui/dashboard/ ./dashboard/
+# Preserve package structure so `ui.dashboard` imports work
+COPY ui/dashboard/ ./ui/dashboard/
 COPY common/ ./common/
 COPY .chainlit/ ./.chainlit/
 


### PR DESCRIPTION
## Summary
- install bash in the chat client Dockerfile so the bash start script works
- enable the dashboard import path inside the container
- activate the Azure Front Door endpoint after deploying infrastructure

## Testing
- `pip install -r agents/requirements-worker.txt`
- `pytest -q` *(fails: KeyError and AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_684fa08b4498832ebb34bd477b46d214