### PR TITLE
Fix wrong sign-in path

### DIFF
--- a/ui/chat_client/templates/login.html
+++ b/ui/chat_client/templates/login.html
@@ -275,7 +275,7 @@
                 </div>
             {% else %}
                 <div id="main-auth">
-                    <a href="/login" class="btn microsoft-btn">
+                    <a href="/auth/login" class="btn microsoft-btn">
                         Sign in with Microsoft
                     </a>
                     


### PR DESCRIPTION
## Summary
- correct Microsoft sign-in link path

## Testing
- `pip install -r agents/requirements-worker.txt`
- `pip install -e vextir_os`
- `pytest -q` *(fails: KeyError: 'model')*

------
https://chatgpt.com/codex/tasks/task_e_684fb5fce674832ebba28fd40177c74d