### PR TITLE
Use integrated dashboard after login

### DIFF
--- a/docs/AUTH_SYSTEM_GUIDE.md
+++ b/docs/AUTH_SYSTEM_GUIDE.md
@@ -32,9 +32,9 @@ The Vextir Chat UI container has been enhanced with a comprehensive authenticati
 - **Admin Panel**: User management interface
 - **API Endpoints**: RESTful admin APIs
 
-### 3. Protected Chat App (`/chat_client/chainlit_app.py`)
-- **Auth Middleware**: Protects chat access
-- **User Context**: Includes user info in conversations
+### 3. Integrated Dashboard (`/integrated_app/app.py`)
+- **Auth Middleware**: Protects all routes
+- **User Context**: Passed to the dashboard and chat views
 - **Health Checks**: Service monitoring
 
 ### 4. Professional UI Templates
@@ -210,7 +210,7 @@ python test_auth_flow.py
 │       └── function.json        # Function configuration
 ├── chat_client/
 │   ├── auth_app.py              # Authentication gateway
-│   ├── chainlit_app.py          # Protected chat app
+│   ├── gateway_app.py           # Mounts auth and integrated UI
 │   ├── start.sh                 # Multi-service startup
 │   ├── Dockerfile               # Container definition
 │   ├── requirements.txt         # Dependencies
@@ -218,6 +218,9 @@ python test_auth_flow.py
 │       ├── login.html           # Login interface
 │       ├── register.html        # Registration interface
 │       └── admin.html           # Admin panel
+├── integrated_app/
+│   ├── app.py                   # Integrated dashboard
+│   └── templates/               # UI pages
 ├── create_admin_user.py         # Admin user creation tool
 ├── test_auth_flow.py            # Comprehensive testing
 └── test_local_auth.py           # Local development testing

--- a/ui/chat_client/gateway_app.py
+++ b/ui/chat_client/gateway_app.py
@@ -2,13 +2,15 @@ from fastapi import FastAPI
 from starlette.responses import RedirectResponse
 
 from auth_app import app as auth_app
-from chainlit_app import fastapi_app as chat_app
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'integrated_app'))
+from app import app as integrated_ui_app
 
 app = FastAPI(title="Vextir Chat Gateway")
 
 # Mount the auth and chat applications under separate routes
 app.mount("/auth", auth_app)
-app.mount("/chat", chat_app)
+app.mount("/app", integrated_ui_app)
 
 @app.get("/", include_in_schema=False)
 async def root():
@@ -20,6 +22,12 @@ async def root():
 async def register_root():
     """Legacy registration path for convenience."""
     return RedirectResponse(url="/auth/register")
+
+
+@app.get("/chat", include_in_schema=False)
+async def legacy_chat():
+    """Backward compatibility for old chat path."""
+    return RedirectResponse(url="/app")
 
 @app.get("/health")
 async def health():

--- a/ui/chat_client/templates/login.html
+++ b/ui/chat_client/templates/login.html
@@ -267,9 +267,9 @@
             {% if request.query_params.get("status") == "pending" or show_pending %}
                 <div class="pending-container">
                     <div class="alert alert-warning">
-                        <h3>⏳ Access Pending</h3>
-                        <p>Your account is authenticated, but access is pending admin approval.</p>
-                        <p>We'll notify you via email once your access is approved.</p>
+                        <h3>⏳ Request Received</h3>
+                        <p>Your account is authenticated, but access is pending.</p>
+                        <p>We'll notify you when services become available.</p>
                     </div>
                     <a href="/logout" class="btn btn-secondary">Sign Out</a>
                 </div>

--- a/ui/chat_client/templates/waitlist.html
+++ b/ui/chat_client/templates/waitlist.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Access Request Received</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; background: #fff; color: #000; display: flex; justify-content: center; align-items: center; min-height: 100vh; }
+        .container { text-align: center; padding: 2rem; }
+        .alert { background-color: #fef3c7; color: #d97706; border: 1px solid #fde68a; padding: 1rem; border-radius: 8px; margin-bottom: 1.5rem; }
+        .btn { display: inline-block; padding: 0.75rem 1.25rem; background: #6c757d; color: #fff; text-decoration: none; border-radius: 8px; }
+        .btn:hover { background: #5a6268; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="alert">
+            <h3>Access Request Received</h3>
+            <p>Your request has been received. We will notify you when services are available.</p>
+        </div>
+        <a href="/logout" class="btn">Sign Out</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- integrate new dashboard app in gateway
- route approved users to the dashboard
- show waitlist page for pending users
- document integrated dashboard in auth guide

## Testing
- `PYTHONPATH=. pytest -q tests/test_chainlit_app.py`
- `PYTHONPATH=. pytest -q` *(fails: KeyError 'model', FileNotFoundError and others)*

------
https://chatgpt.com/codex/tasks/task_e_684fc271be50832ea1eaf692cd2f6146