### PR TITLE
Fix gateway app import path

### DIFF
--- a/ui/chat_client/Dockerfile
+++ b/ui/chat_client/Dockerfile
@@ -14,6 +14,7 @@ COPY ui/chat_client/templates/ ./templates/
 COPY ui/chat_client/static/ ./static/
 COPY ui/chat_client/start.sh ./start.sh
 COPY ui/chat_client/gateway_app.py ./gateway_app.py
+COPY ui/integrated_app/ ./integrated_app/
 COPY events/ ./events/
 # Preserve package structure so `ui.dashboard` imports work
 COPY ui/dashboard/ ./ui/dashboard/

--- a/ui/chat_client/gateway_app.py
+++ b/ui/chat_client/gateway_app.py
@@ -3,7 +3,7 @@ from starlette.responses import RedirectResponse
 
 from auth_app import app as auth_app
 import sys, os
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'integrated_app'))
+sys.path.append(os.path.join(os.path.dirname(__file__), 'integrated_app'))
 from app import app as integrated_ui_app
 
 app = FastAPI(title="Vextir Chat Gateway")


### PR DESCRIPTION
## Summary
- include integrated UI folder in chat container build

## Testing
- `pytest -q` *(fails: KeyError 'model' and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_684fd57cc67c832eb423573f560135a3