### PR TITLE
Fix request access path

### DIFF
--- a/ui/chat_client/gateway_app.py
+++ b/ui/chat_client/gateway_app.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI
-from starlette.responses import RedirectResponse
+from fastapi.responses import RedirectResponse
 
 from auth_app import app as auth_app
 import sys, os
-sys.path.append(os.path.join(os.path.dirname(__file__), 'integrated_app'))
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "integrated_app"))
 from app import app as integrated_ui_app
 
 app = FastAPI(title="Vextir Chat Gateway")
@@ -11,6 +12,7 @@ app = FastAPI(title="Vextir Chat Gateway")
 # Mount the auth and chat applications under separate routes
 app.mount("/auth", auth_app)
 app.mount("/app", integrated_ui_app)
+
 
 @app.get("/", include_in_schema=False)
 async def root():
@@ -24,13 +26,24 @@ async def register_root():
     return RedirectResponse(url="/auth/register")
 
 
+@app.get("/request-access", include_in_schema=False)
+async def request_access_root_get():
+    """Backward compatibility for old request access path."""
+    return RedirectResponse(url="/auth/request-access")
+
+
+@app.post("/request-access", include_in_schema=False)
+async def request_access_root_post():
+    """Redirect POST requests to the authentication service."""
+    return RedirectResponse(url="/auth/request-access")
+
+
 @app.get("/chat", include_in_schema=False)
 async def legacy_chat():
     """Backward compatibility for old chat path."""
     return RedirectResponse(url="/app")
 
+
 @app.get("/health")
 async def health():
     return {"status": "ok"}
-
-

--- a/ui/chat_client/templates/login.html
+++ b/ui/chat_client/templates/login.html
@@ -290,7 +290,7 @@
                         Submit your information and we'll review your access request.
                     </p>
                     
-                    <form action="/request-access" method="post">
+                    <form action="/auth/request-access" method="post">
                         <div class="form-group">
                             <label for="req_name">Name</label>
                             <input type="text" id="req_name" name="name" required>


### PR DESCRIPTION
## Summary
- fix login page link for requesting access
- redirect legacy `/request-access` path to `/auth/request-access`

## Testing
- `pytest -q` *(fails: KeyError, AssertionError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684fe26e1c58832e8239984680bacc22