### PR TITLE
Set AUTH_API_URL for chat ui

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -374,6 +374,10 @@ aad_app = azuread.Application(
             pulumi.Output.concat("https://", domain, "/auth/callback"),
             pulumi.Output.concat("https://www.", domain, "/auth/callback"),
             pulumi.Output.concat("https://hub.", domain, "/auth/callback"),
+            # Support legacy redirect to /auth/login
+            pulumi.Output.concat("https://", domain, "/auth/login"),
+            pulumi.Output.concat("https://www.", domain, "/auth/login"),
+            pulumi.Output.concat("https://hub.", domain, "/auth/login"),
         ]
     ),
 )
@@ -709,6 +713,7 @@ ui_cg = aci_group(
     [
         containerinstance.EnvironmentVariableArgs(name="API_BASE", value=pulumi.Output.concat("https://", func_app.default_host_name)),
         containerinstance.EnvironmentVariableArgs(name="EVENT_API_URL", value=pulumi.Output.concat("https://", func_app.default_host_name, "/api/events")),
+        containerinstance.EnvironmentVariableArgs(name="AUTH_API_URL", value=pulumi.Output.concat("https://", func_app.default_host_name, "/api")),
         containerinstance.EnvironmentVariableArgs(name="AAD_CLIENT_ID", value=aad_app.client_id),
         containerinstance.EnvironmentVariableArgs(name="AAD_CLIENT_SECRET", value=aad_password.value),
         containerinstance.EnvironmentVariableArgs(name="AAD_TENANT_ID", value=aad_tenant_id),

--- a/ui/chat_client/auth_app.py
+++ b/ui/chat_client/auth_app.py
@@ -30,6 +30,8 @@ AAD_CLIENT_SECRET = (
 )
 SESSION_SECRET = os.environ.get("SESSION_SECRET", "change-me")
 AUTH_API_URL = os.environ.get("AUTH_API_URL", "/api")
+# Optional override for external URL of this gateway
+AUTH_GATEWAY_URL = os.environ.get("AUTH_GATEWAY_URL")
 
 if not (AAD_CLIENT_ID and AAD_TENANT_ID and AAD_CLIENT_SECRET):
     logging.warning("AAD configuration incomplete")
@@ -96,7 +98,11 @@ async def root(request: Request):
 
 @app.get("/login")
 async def login(request: Request):
-    """Redirect user to Azure login."""
+    """Redirect user to Azure login or handle callback for legacy redirect."""
+    # If Azure AD redirected here with a code parameter, treat it as a callback
+    if "code" in request.query_params:
+        return await auth_callback(request)
+
     redirect_uri = _resolve_callback_url(request)
     auth_url = auth_app.get_authorization_request_url(SCOPES, redirect_uri=redirect_uri)
     return RedirectResponse(auth_url)
@@ -171,6 +177,9 @@ async def waitlist_page(request: Request):
 
 def _resolve_ui_url(request: Request) -> str:
     """Return external URL for the integrated UI."""
+    if AUTH_GATEWAY_URL:
+        base = AUTH_GATEWAY_URL.rstrip("/")
+        return f"{base}/app"
     forwarded = request.headers.get("x-forwarded-proto")
     scheme = forwarded or request.url.scheme
     host = request.headers.get("x-forwarded-host") or request.url.hostname
@@ -179,6 +188,9 @@ def _resolve_ui_url(request: Request) -> str:
 
 def _resolve_callback_url(request: Request) -> str:
     """Return external URL for the auth callback endpoint."""
+    if AUTH_GATEWAY_URL:
+        base = AUTH_GATEWAY_URL.rstrip("/")
+        return f"{base}/callback"
     url = request.url_for("auth_callback")
     forwarded = request.headers.get("x-forwarded-proto")
     if forwarded:


### PR DESCRIPTION
## Summary
- set `AUTH_API_URL` for chat UI container to point at the function app
- handle Azure AD callbacks arriving on `/auth/login`
- add `/auth/login` URLs to the AAD application's redirect URIs
- allow overriding gateway URL with `AUTH_GATEWAY_URL`

## Testing
- `pytest -q` *(fails: 9 failed, 85 passed, 6 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684fee315570832ea1174b3d9809c576