### PR TITLE
Fix mobile layout for login screen

### DIFF
--- a/ui/chat_client/templates/login.html
+++ b/ui/chat_client/templates/login.html
@@ -221,6 +221,20 @@
             line-height: 1.5;
             margin-bottom: 1rem;
         }
+
+        /* Responsive layout for mobile screens */
+        @media (max-width: 768px) {
+            .main-wrapper {
+                flex-direction: column;
+            }
+            .login-container {
+                order: 1;
+            }
+            .carousel-container {
+                order: 2;
+                width: 100%;
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add mobile media query in login page to stack carousel below login form

## Testing
- `pytest -k login -q` *(fails: ModuleNotFoundError: jsonschema)*

------
https://chatgpt.com/codex/tasks/task_e_68505112b8a4832e9d7f849718669e79