### PR TITLE
Fix login redirect paths

### DIFF
--- a/ui/chat_client/auth_app.py
+++ b/ui/chat_client/auth_app.py
@@ -58,8 +58,10 @@ except Exception as e:
     # Create a dummy auth_app to prevent import errors
     auth_app = None
 
-# Include openid so we get an id_token for verification
-SCOPES = ["User.Read", "openid", "profile"]
+# MSAL automatically adds "openid" and "profile" when needed. Explicitly
+# requesting these reserved scopes results in a runtime error, so we only
+# request the Microsoft Graph scope here.
+SCOPES = ["User.Read"]
 
 app = FastAPI(title="Vextir Chat Authentication")
 app.add_middleware(SessionMiddleware, secret_key=SESSION_SECRET)

--- a/ui/chat_client/templates/admin.html
+++ b/ui/chat_client/templates/admin.html
@@ -38,7 +38,7 @@
                     <a href="/chat" class="bg-white text-purple-600 px-4 py-2 rounded-lg hover:bg-gray-100 transition duration-200">
                         <i class="fas fa-comments mr-2"></i>Go to Chat
                     </a>
-                    <a href="/logout" class="bg-red-500 text-white px-4 py-2 rounded-lg hover:bg-red-600 transition duration-200">
+                    <a href="{{ request.url_for('logout') }}" class="bg-red-500 text-white px-4 py-2 rounded-lg hover:bg-red-600 transition duration-200">
                         <i class="fas fa-sign-out-alt mr-2"></i>Logout
                     </a>
                 </div>

--- a/ui/chat_client/templates/login.html
+++ b/ui/chat_client/templates/login.html
@@ -276,11 +276,11 @@
                         <p>Your account is authenticated, but access is pending.</p>
                         <p>We'll notify you when services become available.</p>
                     </div>
-                    <a href="/logout" class="btn btn-secondary">Sign Out</a>
+                    <a href="{{ request.url_for('logout') }}" class="btn btn-secondary">Sign Out</a>
                 </div>
             {% else %}
                 <div id="main-auth">
-                    <a href="/auth/login" class="btn microsoft-btn">
+                    <a href="{{ request.url_for('login') }}" class="btn microsoft-btn">
                         Sign in with Microsoft
                     </a>
                     
@@ -295,7 +295,7 @@
                         Submit your information and we'll review your access request.
                     </p>
                     
-                    <form action="/auth/request-access" method="post">
+                    <form action="{{ request.url_for('auth_request_access') }}" method="post">
                         <div class="form-group">
                             <label for="req_name">Name</label>
                             <input type="text" id="req_name" name="name" required>

--- a/ui/chat_client/templates/waitlist.html
+++ b/ui/chat_client/templates/waitlist.html
@@ -25,7 +25,7 @@
             <h3>Access Request Received</h3>
             <p>Your request has been received. We will notify you when services are available.</p>
         </div>
-        <a href="/logout" class="btn">Sign Out</a>
+        <a href="{{ request.url_for('logout') }}" class="btn">Sign Out</a>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use `url_for` for login, logout, and request access links
- clarify MSAL scopes for token acquisition

## Testing
- `pip install -r agents/requirements-worker.txt`
- `pip install jsonschema`
- `pytest -q` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_685050d3c41c832eba86d9e654e5194a