### PR TITLE
Fix waitlist redirect

### DIFF
--- a/ui/chat_client/auth_app.py
+++ b/ui/chat_client/auth_app.py
@@ -108,7 +108,7 @@ async def root(request: Request):
             if user_status.get("approved"):
                 return RedirectResponse(url="/app")
             else:
-                return RedirectResponse(url="/waitlist")
+                return RedirectResponse(url=request.url_for("waitlist_page"))
         except Exception:
             pass
     return templates.TemplateResponse("login.html", {"request": request})
@@ -212,7 +212,7 @@ async def auth_callback(request: Request):
                 await request_access(user_id, user_email, user_name)
             
             # Redirect to waitlist page
-            return RedirectResponse(url="/waitlist")
+            return RedirectResponse(url=request.url_for("waitlist_page"))
             
     except Exception as e:
         logger.error(f"Auth callback error: {e}")
@@ -276,7 +276,7 @@ async def chat_redirect(request: Request):
         user_id = verify_token(token)
         user_status = await check_user_approval(user_id)
         if not user_status.get("approved"):
-            return RedirectResponse(url="/waitlist")
+            return RedirectResponse(url=request.url_for("waitlist_page"))
     except Exception:
         return RedirectResponse(url="/login")
     return RedirectResponse(_resolve_ui_url(request))

--- a/ui/chat_client/gateway_app.py
+++ b/ui/chat_client/gateway_app.py
@@ -44,6 +44,12 @@ async def legacy_chat():
     return RedirectResponse(url="/app")
 
 
+@app.get("/waitlist", include_in_schema=False)
+async def waitlist_root():
+    """Redirect to the authentication waitlist page."""
+    return RedirectResponse(url="/auth/waitlist")
+
+
 @app.get("/health")
 async def health():
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- fix redirects to waitlist page so it uses mounted path
- add gateway alias for `/waitlist`

## Testing
- `pytest -q` *(fails: KeyError 'model' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6850d8e812f0832e93628bab6b668c21